### PR TITLE
Add big_space plugin for large world support

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,5 +22,6 @@ random_word = { version = "0.5.0", features = ["en"] }
 rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
+big_space = "0.9"
 
 

--- a/client/src/app.rs
+++ b/client/src/app.rs
@@ -1,10 +1,12 @@
 use crate::helper::debug_gizmos::debug_gizmos;
 use bevy::prelude::*;
+use big_space::prelude::*;
 pub struct AppPlugin;
 
 impl Plugin for AppPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(crate::plugins::ui::ui_plugin::UiPlugin);
+        app.add_plugins(crate::plugins::big_space::big_space_plugin::BigSpaceIntegrationPlugin);
         app.add_plugins(crate::plugins::environment::environment_plugin::EnvironmentPlugin);
         //app.add_plugins(crate::plugins::network::network_plugin::NetworkPlugin);
         app.add_plugins(crate::plugins::input::input_plugin::InputPlugin);

--- a/client/src/plugins/big_space/big_space_plugin.rs
+++ b/client/src/plugins/big_space/big_space_plugin.rs
@@ -1,0 +1,14 @@
+use bevy::prelude::*;
+use big_space::prelude::*;
+
+/// Plugin enabling high precision coordinates using `big_space`.
+///
+/// This sets up [`BigSpacePlugin`] so entities can be placed far from the origin
+/// without losing precision.
+pub struct BigSpaceIntegrationPlugin;
+
+impl Plugin for BigSpaceIntegrationPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(BigSpacePlugin::<i64>::default());
+    }
+}

--- a/client/src/plugins/big_space/mod.rs
+++ b/client/src/plugins/big_space/mod.rs
@@ -1,0 +1,1 @@
+pub mod big_space_plugin;

--- a/client/src/plugins/environment/systems/camera_system.rs
+++ b/client/src/plugins/environment/systems/camera_system.rs
@@ -3,6 +3,7 @@ use bevy::input::mouse::{MouseMotion, MouseWheel};
 use bevy::math::Vec3;
 use bevy::prelude::*;
 use bevy_render::camera::{Exposure, PhysicalCameraParameters, Projection};
+use big_space::prelude::*;
 use bevy_window::CursorGrabMode;
 use rand::Rng;
 use random_word::Lang;
@@ -28,25 +29,25 @@ impl Default for CameraController {
     }
 }
 
-pub fn setup(mut commands: Commands,) {
-    
-
-    commands.spawn((
-        Transform::from_xyz(0.0, 0.0, 10.0), // initial f32
-        GlobalTransform::default(),
-        Camera3d::default(),
-        Projection::from(PerspectiveProjection {
-            near: 0.0001,
-            ..default()
-        }),
-        CameraController::default(),
-        Exposure::from_physical_camera(PhysicalCameraParameters {
-            aperture_f_stops: 1.0,
-            shutter_speed_s: 1.0 / 125.0,
-            sensitivity_iso: 100.0,
-            sensor_height: 0.01866,
-        }),
-
-    ));
+pub fn setup(mut commands: Commands) {
+    commands.spawn_big_space_default::<i64>(|root| {
+        root.spawn_spatial((
+            Transform::from_xyz(0.0, 0.0, 10.0), // initial position
+            GlobalTransform::default(),
+            Camera3d::default(),
+            Projection::from(PerspectiveProjection {
+                near: 0.0001,
+                ..default()
+            }),
+            CameraController::default(),
+            Exposure::from_physical_camera(PhysicalCameraParameters {
+                aperture_f_stops: 1.0,
+                shutter_speed_s: 1.0 / 125.0,
+                sensitivity_iso: 100.0,
+                sensor_height: 0.01866,
+            }),
+            FloatingOrigin,
+        ));
+    });
 }
 

--- a/client/src/plugins/mod.rs
+++ b/client/src/plugins/mod.rs
@@ -3,3 +3,4 @@ pub mod environment;
 pub mod ui;
 pub mod network;
 pub mod input;
+pub mod big_space;


### PR DESCRIPTION
## Summary
- enable extremely large worlds via `big_space` plugin
- use `spawn_big_space_default` in camera setup
- register `BigSpaceIntegrationPlugin` during app startup

## Testing
- `cargo check --workspace` *(fails: system library `alsa` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f41448ff88326a31d00ddb74a64be