### PR TITLE
Add basic voxel LOD system

### DIFF
--- a/client/src/plugins/environment/environment_plugin.rs
+++ b/client/src/plugins/environment/environment_plugin.rs
@@ -1,11 +1,26 @@
 use bevy::app::{App, Plugin, PreStartup, PreUpdate, Startup};
 use bevy::prelude::*;
-use crate::plugins::environment::systems::voxels::culling::{despawn_distant_chunks};
+use crate::plugins::environment::systems::voxels::culling::{
+    despawn_distant_chunks,
+    replace_near_lod_chunks,
+};
 use crate::plugins::environment::systems::voxels::debug::{draw_grid, visualize_octree_system};
 use crate::plugins::environment::systems::voxels::queue_systems;
-use crate::plugins::environment::systems::voxels::queue_systems::{enqueue_visible_chunks, process_chunk_queue};
+use crate::plugins::environment::systems::voxels::queue_systems::{
+    enqueue_visible_chunks,
+    process_chunk_queue,
+    enqueue_lod_chunks,
+    process_lod_chunk_queue,
+};
 use crate::plugins::environment::systems::voxels::render_chunks::rebuild_dirty_chunks;
-use crate::plugins::environment::systems::voxels::structure::{ChunkBudget, ChunkCullingCfg, ChunkQueue, SparseVoxelOctree, SpawnedChunks};
+use crate::plugins::environment::systems::voxels::structure::{
+    ChunkBudget,
+    ChunkCullingCfg,
+    ChunkQueue,
+    LodChunkQueue,
+    SparseVoxelOctree,
+    SpawnedChunks,
+};
 
 pub struct EnvironmentPlugin;
 impl Plugin for EnvironmentPlugin {
@@ -21,7 +36,11 @@ impl Plugin for EnvironmentPlugin {
             ),
         );
 
-        app.insert_resource(ChunkCullingCfg { view_distance_chunks: 10 });
+        app.insert_resource(ChunkCullingCfg {
+            view_distance_chunks: 10,
+            lod_distance_chunks: 20,
+            lod_level: 2,
+        });
         app.insert_resource(ChunkBudget { per_frame: 20 });
         
         app
@@ -29,6 +48,7 @@ impl Plugin for EnvironmentPlugin {
             // resources
             // ------------------------------------------------------------------------
             .init_resource::<ChunkQueue>()
+            .init_resource::<LodChunkQueue>()
             .init_resource::<SpawnedChunks>()
             // ------------------------------------------------------------------------
             // frame update
@@ -37,11 +57,13 @@ impl Plugin for EnvironmentPlugin {
                 Update,
                 (
                     /* ---------- culling & streaming ---------- */
-                    despawn_distant_chunks,                       // 1.  remove too-far chunks
-                    enqueue_visible_chunks.after(despawn_distant_chunks),         // 2.  find new visible ones
-                    process_chunk_queue .after(enqueue_visible_chunks),           // 3.  spawn ≤ budget per frame
-                    rebuild_dirty_chunks .after(process_chunk_queue),             // 4.  (re)mesh dirty chunks
-
+                    despawn_distant_chunks,
+                    replace_near_lod_chunks.after(despawn_distant_chunks),
+                    enqueue_visible_chunks.after(replace_near_lod_chunks),         // 2.  find new visible ones
+                    process_chunk_queue .after(enqueue_visible_chunks),          // 3.  spawn ≤ budget per frame
+                    enqueue_lod_chunks.after(process_chunk_queue),
+                    process_lod_chunk_queue.after(enqueue_lod_chunks),
+                    rebuild_dirty_chunks .after(process_lod_chunk_queue),          // 4.  (re)mesh dirty chunks
                     /* ---------- optional debug drawing ------- */
                     visualize_octree_system
                         .run_if(should_visualize_octree)

--- a/client/src/plugins/environment/systems/voxels/culling.rs
+++ b/client/src/plugins/environment/systems/voxels/culling.rs
@@ -12,20 +12,53 @@ pub fn despawn_distant_chunks(
     cam_q          : Query<&GlobalTransform, With<Camera>>,
     tree_q         : Query<&SparseVoxelOctree>,
     mut spawned    : ResMut<SpawnedChunks>,
-    chunk_q        : Query<&Chunk>,
+    chunk_q        : Query<(&Chunk, Option<&LodLevel>)>,
     cfg            : Res<ChunkCullingCfg>,
 ) {
     let tree   = tree_q.single();
     let cam    = cam_q.single().translation();
     let center = world_to_chunk(tree, cam);
 
-    for chunk in chunk_q.iter() {
+    for (chunk, lod) in chunk_q.iter() {
+        let range = if lod.map_or(0, |l| l.0) == 0 {
+            cfg.view_distance_chunks
+        } else {
+            cfg.lod_distance_chunks
+        };
         let ChunkKey(x, y, z) = chunk.key;
-        if  (x - center.0).abs() > cfg.view_distance_chunks ||
-            (y - center.1).abs() > cfg.view_distance_chunks ||
-            (z - center.2).abs() > cfg.view_distance_chunks {
+        if  (x - center.0).abs() > range ||
+            (y - center.1).abs() > range ||
+            (z - center.2).abs() > range {
             if let Some(ent) = spawned.0.remove(&chunk.key) {
                 commands.entity(ent).despawn_recursive();
+            }
+        }
+    }
+}
+
+/// remove low resolution chunks that moved within the high-res radius
+pub fn replace_near_lod_chunks(
+    mut commands   : Commands,
+    cam_q          : Query<&GlobalTransform, With<Camera>>,
+    tree_q         : Query<&SparseVoxelOctree>,
+    mut spawned    : ResMut<SpawnedChunks>,
+    chunk_q        : Query<(Entity, &Chunk, Option<&LodLevel>)>,
+    cfg            : Res<ChunkCullingCfg>,
+) {
+    let tree   = tree_q.single();
+    let cam    = cam_q.single().translation();
+    let center = world_to_chunk(tree, cam);
+
+    for (entity, chunk, lod) in chunk_q.iter() {
+        if let Some(lod) = lod {
+            if lod.0 > 0 {
+                let ChunkKey(x, y, z) = chunk.key;
+                if (x - center.0).abs() <= cfg.view_distance_chunks &&
+                   (y - center.1).abs() <= cfg.view_distance_chunks &&
+                   (z - center.2).abs() <= cfg.view_distance_chunks {
+                    commands.entity(entity).despawn_recursive();
+                    spawned.0.remove(&chunk.key);
+                }
             }
         }
     }

--- a/client/src/plugins/environment/systems/voxels/queue_systems.rs
+++ b/client/src/plugins/environment/systems/voxels/queue_systems.rs
@@ -62,3 +62,92 @@ pub fn process_chunk_queue(
         } else { break; }
     }
 }
+
+/// enqueue far away chunks for low resolution rendering when nothing close is queued
+pub fn enqueue_lod_chunks(
+    mut queue      : ResMut<LodChunkQueue>,
+    spawned        : Res<SpawnedChunks>,
+    cfg            : Res<ChunkCullingCfg>,
+    cam_q          : Query<&GlobalTransform, With<Camera>>,
+    tree_q         : Query<&SparseVoxelOctree>,
+    main_queue     : Res<ChunkQueue>,
+) {
+    if !main_queue.0.is_empty() { return; }
+
+    let tree    = tree_q.single();
+    let cam_pos = cam_q.single().translation();
+    let centre  = world_to_chunk(tree, cam_pos);
+    let r_far   = cfg.lod_distance_chunks;
+    let r_near  = cfg.view_distance_chunks;
+
+    for dx in -r_far..=r_far {
+        for dy in -r_far..=r_far {
+            for dz in -r_far..=r_far {
+                // skip near range
+                if dx.abs() <= r_near && dy.abs() <= r_near && dz.abs() <= r_near { continue; }
+                let key = ChunkKey(centre.0 + dx, centre.1 + dy, centre.2 + dz);
+                if spawned.0.contains_key(&key) { continue; }
+                if queue.0.contains(&key) { continue; }
+                if !tree.chunk_has_any_voxel(key) { continue; }
+                queue.0.push_back(key);
+            }
+        }
+    }
+}
+
+/// spawn low resolution chunk meshes directly from the LOD queue
+pub fn process_lod_chunk_queue(
+    mut commands   : Commands,
+    mut queue      : ResMut<LodChunkQueue>,
+    budget         : Res<ChunkBudget>,
+    tree_q         : Query<&SparseVoxelOctree>,
+    mut meshes     : ResMut<Assets<Mesh>>,
+    mut materials  : ResMut<Assets<StandardMaterial>>,
+    mut spawned    : ResMut<SpawnedChunks>,
+    root           : Res<RootGrid>,
+    cfg            : Res<ChunkCullingCfg>,
+) {
+    let tree = tree_q.single();
+    let step = tree.get_spacing_at_depth(tree.max_depth.saturating_sub(cfg.lod_level));
+    let half = tree.size * 0.5;
+
+    for _ in 0..budget.per_frame {
+        if let Some(key) = queue.0.pop_front() {
+            if spawned.0.contains_key(&key) { continue; }
+
+            let mut buf = [[[None; CHUNK_SIZE as usize]; CHUNK_SIZE as usize]; CHUNK_SIZE as usize];
+            let origin = Vec3::new(
+                key.0 as f32 * CHUNK_SIZE as f32 * step - half,
+                key.1 as f32 * CHUNK_SIZE as f32 * step - half,
+                key.2 as f32 * CHUNK_SIZE as f32 * step - half,
+            );
+
+            for lx in 0..CHUNK_SIZE {
+                for ly in 0..CHUNK_SIZE {
+                    for lz in 0..CHUNK_SIZE {
+                        let world = origin + Vec3::new(lx as f32 * step, ly as f32 * step, lz as f32 * step);
+                        if let Some(v) = tree.get_voxel_at_world_coords(world) {
+                            buf[lx as usize][ly as usize][lz as usize] = Some(*v);
+                        }
+                    }
+                }
+            }
+
+            let mesh_handle = meshes.add(mesh_chunk(&buf, origin, step, tree));
+            let mesh_3d     = Mesh3d::from(mesh_handle);
+            let material    = MeshMaterial3d::<StandardMaterial>::default();
+
+            commands.entity(root.0).with_children(|p| {
+                let e = p.spawn((
+                    mesh_3d,
+                    material,
+                    Transform::default(),
+                    GridCell::<i64>::ZERO,
+                    Chunk { key, voxels: Vec::new(), dirty: false },
+                    LodLevel(cfg.lod_level),
+                )).id();
+                spawned.0.insert(key, e);
+            });
+        } else { break; }
+    }
+}

--- a/client/src/plugins/environment/systems/voxels/structure.rs
+++ b/client/src/plugins/environment/systems/voxels/structure.rs
@@ -121,5 +121,28 @@ pub struct SpawnedChunks(pub HashMap<ChunkKey, Entity>);
 
 /// how big the cube around the player is, measured in chunks
 #[derive(Resource)]
-pub struct ChunkCullingCfg { pub view_distance_chunks: i32 }
-impl Default for ChunkCullingCfg { fn default() -> Self { Self { view_distance_chunks: 6 } } }
+pub struct ChunkCullingCfg {
+    /// full resolution view distance
+    pub view_distance_chunks: i32,
+    /// additional distance for low resolution rendering
+    pub lod_distance_chunks: i32,
+    /// how many octree levels to skip when meshing far chunks
+    pub lod_level: u32,
+}
+impl Default for ChunkCullingCfg {
+    fn default() -> Self {
+        Self {
+            view_distance_chunks: 6,
+            lod_distance_chunks: 12,
+            lod_level: 2,
+        }
+    }
+}
+
+/// component marking the level of detail of a spawned chunk
+#[derive(Component)]
+pub struct LodLevel(pub u32);
+
+/// queue of far LOD chunks
+#[derive(Resource, Default)]
+pub struct LodChunkQueue(pub VecDeque<ChunkKey>);


### PR DESCRIPTION
## Summary
- extend chunk structures with LOD config, level component and queue
- despawn distant chunks using view and LOD radii
- replace low resolution chunks when moving close
- enqueue and process far LOD chunks when main queue is empty
- wire new systems and resources in `EnvironmentPlugin`

## Testing
- `cargo check` *(fails: system library `alsa` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845124cd81c832698189080ba7edbfa