### PR TITLE
Improve voxel performance

### DIFF
--- a/client/src/plugins/environment/environment_plugin.rs
+++ b/client/src/plugins/environment/environment_plugin.rs
@@ -6,7 +6,7 @@ use crate::plugins::environment::systems::voxels::queue_systems;
 use crate::plugins::environment::systems::voxels::queue_systems::{enqueue_visible_chunks, process_chunk_queue};
 use crate::plugins::environment::systems::voxels::render_chunks::rebuild_dirty_chunks;
 use crate::plugins::environment::systems::voxels::lod::update_chunk_lods;
-use crate::plugins::environment::systems::voxels::structure::{ChunkBudget, ChunkCullingCfg, ChunkQueue, SparseVoxelOctree, SpawnedChunks, ChunkOffsets, PrevCameraChunk};
+use crate::plugins::environment::systems::voxels::structure::{ChunkBudget, ChunkCullingCfg, ChunkQueue, SparseVoxelOctree, SpawnedChunks, PrevCameraChunk};
 
 pub struct EnvironmentPlugin;
 impl Plugin for EnvironmentPlugin {
@@ -25,7 +25,6 @@ impl Plugin for EnvironmentPlugin {
         let view_distance_chunks = 100;
         app.insert_resource(ChunkCullingCfg { view_distance_chunks });
         app.insert_resource(ChunkBudget { per_frame: 20 });
-        app.insert_resource(ChunkOffsets::new(view_distance_chunks));
         app.init_resource::<PrevCameraChunk>();
         app.add_systems(Update, log_mesh_count);
         app

--- a/client/src/plugins/environment/systems/voxels/lod.rs
+++ b/client/src/plugins/environment/systems/voxels/lod.rs
@@ -11,31 +11,28 @@ pub fn update_chunk_lods(
     cfg: Res<ChunkCullingCfg>,
 ) {
     let cam_pos = cam_q.single().translation();
-    let (max_depth, range_step, chunk_size);
-    {
-        let tree = tree_q.single();
-        max_depth = tree.max_depth;
-        range_step = cfg.view_distance_chunks as f32 / max_depth as f32;
-        chunk_size = CHUNK_SIZE as f32 * tree.get_spacing_at_depth(max_depth);
-    }
+
+    // Borrow the octree only once to avoid repeated query lookups
+    let mut tree = tree_q.single_mut();
+    let max_depth = tree.max_depth;
+    let range_step = cfg.view_distance_chunks as f32 / max_depth as f32;
+    let chunk_size = CHUNK_SIZE as f32 * tree.get_spacing_at_depth(max_depth);
 
     let mut changed = Vec::new();
     for (chunk, mut lod) in chunks.iter_mut() {
-        let tree = tree_q.single();
         let center = chunk_center_world(&tree, chunk.key);
         let dist_chunks = cam_pos.distance(center) / chunk_size;
         let mut level = (dist_chunks / range_step).floor() as u32;
-        if level > max_depth { level = max_depth; }
+        if level > max_depth {
+            level = max_depth;
+        }
         if lod.0 != level {
             lod.0 = level;
             changed.push(chunk.key);
         }
     }
 
-    if !changed.is_empty() {
-        let mut tree = tree_q.single_mut();
-        for key in changed {
-            tree.dirty_chunks.insert(key);
-        }
+    for key in changed {
+        tree.dirty_chunks.insert(key);
     }
 }

--- a/client/src/plugins/environment/systems/voxels/structure.rs
+++ b/client/src/plugins/environment/systems/voxels/structure.rs
@@ -118,7 +118,10 @@ impl Default for ChunkBudget {
 
 /// FIFO queue with chunk keys that still need meshing
 #[derive(Resource, Default)]
-pub struct ChunkQueue(pub VecDeque<ChunkKey>);
+pub struct ChunkQueue {
+    pub keys: VecDeque<ChunkKey>,
+    pub set:  HashSet<ChunkKey>,
+}
 
 /// map “which chunk key already has an entity in the world?”
 #[derive(Resource, Default)]


### PR DESCRIPTION
## Summary
- avoid iterating millions of offsets by checking occupied chunks directly
- track enqueued chunks in a HashSet for O(1) lookup
- remove unused `ChunkOffsets` from plugin setup

## Testing
- `cargo fmt --all` *(failed: `cargo-fmt` component missing)*
- `cargo check` *(failed: could not find system library `alsa`)*

------
https://chatgpt.com/codex/tasks/task_e_68469aabdfe083269f3d08e7feab9387