### PR TITLE
Add distance-based voxel loading

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,5 +22,6 @@ random_word = { version = "0.5.0", features = ["en"] }
 rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
+bincode = "1.3"
 
 

--- a/client/src/helper/mod.rs
+++ b/client/src/helper/mod.rs
@@ -1,3 +1,4 @@
 pub mod debug_gizmos;
 pub mod vector_helper;
 pub mod math;
+pub mod octree;

--- a/client/src/helper/octree.rs
+++ b/client/src/helper/octree.rs
@@ -1,0 +1,55 @@
+use serde::{Serialize, Deserialize, de::DeserializeOwned};
+use std::collections::VecDeque;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct OctreeNode<T> {
+    pub children: [Option<Box<OctreeNode<T>>>; 8],
+    pub data: Vec<T>,
+}
+
+impl<T> Default for OctreeNode<T> {
+    fn default() -> Self {
+        Self {
+            children: std::array::from_fn(|_| None),
+            data: Vec::new(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct Octree<T> {
+    pub root: OctreeNode<T>,
+}
+
+impl<T> Octree<T>
+where
+    T: Serialize + DeserializeOwned + Clone,
+{
+    pub fn new() -> Self {
+        Self { root: OctreeNode::default() }
+    }
+
+    pub fn save_to_file<P: AsRef<std::path::Path>>(&self, path: P) -> std::io::Result<()> {
+        let bytes = bincode::serialize(self).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        std::fs::write(path, bytes)
+    }
+
+    pub fn load_from_file<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<Self> {
+        let data = std::fs::read(path)?;
+        let tree = bincode::deserialize(&data).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        Ok(tree)
+    }
+
+    pub fn collect_data(&self, out: &mut VecDeque<T>) {
+        self.root.collect_data(out);
+    }
+}
+
+impl<T: Clone> OctreeNode<T> {
+    fn collect_data(&self, out: &mut VecDeque<T>) {
+        out.extend(self.data.clone());
+        for child in self.children.iter().flatten() {
+            child.collect_data(out);
+        }
+    }
+}

--- a/client/src/plugins/environment/environment_plugin.rs
+++ b/client/src/plugins/environment/environment_plugin.rs
@@ -1,13 +1,17 @@
-use bevy::app::{App, Plugin, PreStartup, PreUpdate, Startup};
+use bevy::app::{App, Plugin, Startup, Update};
+use crate::plugins::world::systems::{load_octree, progressive_load};
 pub struct EnvironmentPlugin;
 impl Plugin for EnvironmentPlugin {
     fn build(&self, app: &mut App) {
 
         app.add_systems(
             Startup,
-            (crate::plugins::environment::systems::environment_system::setup, crate::plugins::environment::systems::camera_system::setup ),
+            (
+                crate::plugins::environment::systems::environment_system::setup,
+                crate::plugins::environment::systems::camera_system::setup,
+                load_octree,
+            ),
         );
-        
-        
+        app.add_systems(Update, progressive_load);
     }
 }

--- a/client/src/plugins/mod.rs
+++ b/client/src/plugins/mod.rs
@@ -3,3 +3,4 @@ pub mod environment;
 pub mod ui;
 pub mod network;
 pub mod input;
+pub mod world;

--- a/client/src/plugins/world/mod.rs
+++ b/client/src/plugins/world/mod.rs
@@ -1,0 +1,2 @@
+pub mod systems;
+pub mod types;

--- a/client/src/plugins/world/systems.rs
+++ b/client/src/plugins/world/systems.rs
@@ -1,0 +1,58 @@
+use bevy::prelude::*;
+use std::collections::VecDeque;
+use std::path::Path;
+use crate::helper::octree::Octree;
+use super::types::Voxel;
+
+fn sort_voxels(queue: &mut VecDeque<Voxel>, camera_pos: Vec3) {
+    let mut vec: Vec<Voxel> = queue.drain(..).collect();
+    vec.sort_by(|a, b| {
+        let da = camera_pos.distance_squared(a.to_vec3());
+        let db = camera_pos.distance_squared(b.to_vec3());
+        da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
+    });
+    *queue = vec.into();
+}
+
+#[derive(Resource)]
+pub struct WorldOctree(pub Octree<Voxel>);
+
+#[derive(Resource)]
+pub struct LoadingQueue(pub VecDeque<Voxel>);
+
+pub fn load_octree(mut commands: Commands, camera_query: Query<&Transform, With<Camera3d>>) {
+    let path = Path::new("assets/world.bin");
+    let tree = Octree::<Voxel>::load_from_file(path).unwrap_or_else(|_| Octree::new());
+    let mut queue = VecDeque::new();
+    tree.collect_data(&mut queue);
+    if let Ok(camera) = camera_query.get_single() {
+        sort_voxels(&mut queue, camera.translation);
+    }
+    commands.insert_resource(WorldOctree(tree));
+    commands.insert_resource(LoadingQueue(queue));
+}
+
+pub fn progressive_load(
+    mut commands: Commands,
+    mut queue: ResMut<LoadingQueue>,
+    camera_query: Query<&Transform, With<Camera3d>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    if let Ok(camera) = camera_query.get_single() {
+        sort_voxels(&mut queue.0, camera.translation);
+    }
+    let per_frame = 5;
+    for _ in 0..per_frame {
+        if let Some(voxel) = queue.0.pop_front() {
+            commands.spawn(PbrBundle {
+                mesh: meshes.add(Cuboid::default()),
+                material: materials.add(StandardMaterial::default()),
+                transform: Transform::from_translation(voxel.to_vec3()),
+                ..default()
+            });
+        } else {
+            break;
+        }
+    }
+}

--- a/client/src/plugins/world/types.rs
+++ b/client/src/plugins/world/types.rs
@@ -1,0 +1,13 @@
+use serde::{Serialize, Deserialize};
+use bevy::prelude::Vec3;
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Voxel {
+    pub position: [f32; 3],
+}
+
+impl Voxel {
+    pub fn to_vec3(&self) -> Vec3 {
+        Vec3::new(self.position[0], self.position[1], self.position[2])
+    }
+}


### PR DESCRIPTION
## Summary
- add helper to sort voxels relative to the camera
- sort the loading queue on startup and each frame
- persist and load voxel data via Octree
- integrate world loading systems into `EnvironmentPlugin`

## Testing
- `cargo check --workspace` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684707bc558c8326a4aeb53322ed0e5c