### PR TITLE
Add GPU compute pipeline for voxel generation

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -21,4 +21,6 @@ smallvec = "1.14.0"
 once_cell = "1.21.3"
 rayon = "1.10.0"
 bincode = "1.3"
+bevy_easy_compute = "0.15"
+bytemuck = { version = "1", features = ["derive"] }
 

--- a/client/assets/shaders/chunk_lod.wgsl
+++ b/client/assets/shaders/chunk_lod.wgsl
@@ -1,0 +1,29 @@
+struct Params {
+    centre: vec3<i32>;
+    max_level: u32;
+    range_step: f32;
+    count: u32;
+    _pad: u32;
+};
+
+@group(0) @binding(0)
+var<uniform> params: Params;
+
+@group(0) @binding(1)
+var<storage, read> keys_in: array<vec3<i32>>;
+
+@group(0) @binding(2)
+var<storage, read_write> lod_out: array<u32>;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    let idx = id.x;
+    if (idx >= params.count) { return; }
+    let key = keys_in[idx];
+    let dx = f32(key.x - params.centre.x);
+    let dy = f32(key.y - params.centre.y);
+    let dz = f32(key.z - params.centre.z);
+    var level = floor(length(vec3<f32>(dx, dy, dz)) / params.range_step);
+    if (level > f32(params.max_level)) { level = f32(params.max_level); }
+    lod_out[idx] = u32(level);
+}

--- a/client/assets/shaders/chunk_mesh.wgsl
+++ b/client/assets/shaders/chunk_mesh.wgsl
@@ -1,0 +1,119 @@
+struct Params {
+    origin: vec3<f32>;
+    step: f32;
+};
+
+@group(0) @binding(0)
+var<uniform> params: Params;
+
+@group(0) @binding(1)
+var<storage, read> voxels: array<u32>;
+
+@group(0) @binding(2)
+var<storage, read_write> positions: array<vec3<f32>>;
+
+@group(0) @binding(3)
+var<storage, read_write> normals: array<vec3<f32>>;
+
+@group(0) @binding(4)
+var<storage, read_write> uvs: array<vec2<f32>>;
+
+@group(0) @binding(5)
+var<storage, read_write> indices: array<u32>;
+
+struct Counts {
+    vertex: atomic<u32>;
+    index: atomic<u32>;
+};
+
+@group(0) @binding(6)
+var<storage, read_write> counts: Counts;
+
+const N: u32 = 16u;
+
+fn push_face(base: vec3<f32>, size: vec2<f32>, n: vec3<f32>, u: vec3<f32>, v: vec3<f32>) {
+    let vi = atomicAdd(&counts.vertex, 4u);
+    positions[vi + 0u] = base;
+    positions[vi + 1u] = base + u * size.x;
+    positions[vi + 2u] = base + u * size.x + v * size.y;
+    positions[vi + 3u] = base + v * size.y;
+    normals[vi + 0u] = n;
+    normals[vi + 1u] = n;
+    normals[vi + 2u] = n;
+    normals[vi + 3u] = n;
+    uvs[vi + 0u] = vec2<f32>(0.0, 1.0);
+    uvs[vi + 1u] = vec2<f32>(1.0, 1.0);
+    uvs[vi + 2u] = vec2<f32>(1.0, 0.0);
+    uvs[vi + 3u] = vec2<f32>(0.0, 0.0);
+    let ii = atomicAdd(&counts.index, 6u);
+    if (n.x + n.y + n.z >= 0.0) {
+        indices[ii + 0u] = vi;
+        indices[ii + 1u] = vi + 1u;
+        indices[ii + 2u] = vi + 2u;
+        indices[ii + 3u] = vi + 2u;
+        indices[ii + 4u] = vi + 3u;
+        indices[ii + 5u] = vi;
+    } else {
+        indices[ii + 0u] = vi;
+        indices[ii + 1u] = vi + 3u;
+        indices[ii + 2u] = vi + 2u;
+        indices[ii + 3u] = vi + 2u;
+        indices[ii + 4u] = vi + 1u;
+        indices[ii + 5u] = vi;
+    }
+}
+
+@compute @workgroup_size(1,1,1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    if (gid.x > 0u) { return; }
+    let s = params.step;
+    for (var z: u32 = 0u; z < N; z = z + 1u) {
+        for (var y: u32 = 0u; y < N; y = y + 1u) {
+            for (var x: u32 = 0u; x < N; x = x + 1u) {
+                let idx = z * N * N + y * N + x;
+                if (voxels[idx] == 0u) { continue; }
+                let base = params.origin + vec3<f32>(f32(x) * s, f32(y) * s, f32(z) * s);
+                var filled: bool;
+                // -X
+                filled = false;
+                if (x > 0u) { filled = voxels[idx - 1u] != 0u; }
+                if (!filled) {
+                    push_face(base, vec2<f32>(s, s), vec3<f32>(-1.0,0.0,0.0), vec3<f32>(0.0,0.0,s), vec3<f32>(0.0,s,0.0));
+                }
+                // +X
+                filled = false;
+                if (x + 1u < N) { filled = voxels[idx + 1u] != 0u; }
+                if (!filled) {
+                    let b = base + vec3<f32>(s,0.0,0.0);
+                    push_face(b, vec2<f32>(s, s), vec3<f32>(1.0,0.0,0.0), vec3<f32>(0.0,s,0.0), vec3<f32>(0.0,0.0,s));
+                }
+                // -Y
+                filled = false;
+                if (y > 0u) { filled = voxels[idx - N] != 0u; }
+                if (!filled) {
+                    push_face(base, vec2<f32>(s, s), vec3<f32>(0.0,-1.0,0.0), vec3<f32>(s,0.0,0.0), vec3<f32>(0.0,0.0,s));
+                }
+                // +Y
+                filled = false;
+                if (y + 1u < N) { filled = voxels[idx + N] != 0u; }
+                if (!filled) {
+                    let b = base + vec3<f32>(0.0,s,0.0);
+                    push_face(b, vec2<f32>(s, s), vec3<f32>(0.0,1.0,0.0), vec3<f32>(0.0,0.0,s), vec3<f32>(s,0.0,0.0));
+                }
+                // -Z
+                filled = false;
+                if (z > 0u) { filled = voxels[idx - N * N] != 0u; }
+                if (!filled) {
+                    push_face(base, vec2<f32>(s, s), vec3<f32>(0.0,0.0,-1.0), vec3<f32>(s,0.0,0.0), vec3<f32>(0.0,s,0.0));
+                }
+                // +Z
+                filled = false;
+                if (z + 1u < N) { filled = voxels[idx + N * N] != 0u; }
+                if (!filled) {
+                    let b = base + vec3<f32>(0.0,0.0,s);
+                    push_face(b, vec2<f32>(s, s), vec3<f32>(0.0,0.0,1.0), vec3<f32>(s,0.0,0.0), vec3<f32>(0.0,s,0.0));
+                }
+            }
+        }
+    }
+}

--- a/client/assets/shaders/noise.wgsl
+++ b/client/assets/shaders/noise.wgsl
@@ -1,0 +1,42 @@
+struct Params {
+    frequency: f32,
+    amplitude: f32,
+    width: u32,
+    depth: u32,
+};
+
+@group(0) @binding(0)
+var<uniform> params: Params;
+
+@group(0) @binding(1)
+var<storage, read_write> heights: array<f32>;
+
+fn hash(p: vec2<i32>) -> f32 {
+    let dot_val = f32(p.x * 1271 + p.y * 3117);
+    return fract(sin(dot_val) * 43758.5453);
+}
+
+fn noise(p: vec2<f32>) -> f32 {
+    let i = vec2<i32>(floor(p));
+    let f = fract(p);
+
+    let a = hash(i);
+    let b = hash(i + vec2<i32>(1,0));
+    let c = hash(i + vec2<i32>(0,1));
+    let d = hash(i + vec2<i32>(1,1));
+
+    let u = f * f * (3.0 - 2.0 * f);
+
+    return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
+}
+
+@compute @workgroup_size(8,8,1)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    if (id.x >= params.width || id.y >= params.depth) {
+        return;
+    }
+    let index = id.y * params.width + id.x;
+    let pos = vec2<f32>(f32(id.x), f32(id.y)) * params.frequency;
+    let n = noise(pos);
+    heights[index] = n * params.amplitude;
+}

--- a/client/assets/shaders/sphere.wgsl
+++ b/client/assets/shaders/sphere.wgsl
@@ -1,0 +1,24 @@
+struct Params {
+    radius: u32,
+    diameter: u32,
+};
+
+@group(0) @binding(0)
+var<uniform> params: Params;
+
+@group(0) @binding(1)
+var<storage, read_write> voxels: array<u32>;
+
+@compute @workgroup_size(8,8,8)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    if (id.x >= params.diameter || id.y >= params.diameter || id.z >= params.diameter) {
+        return;
+    }
+    let r = f32(params.radius);
+    let cx = f32(id.x) - r;
+    let cy = f32(id.y) - r;
+    let cz = f32(id.z) - r;
+    let inside = select(0u, 1u, cx * cx + cy * cy + cz * cz <= r * r);
+    let index = id.z * params.diameter * params.diameter + id.y * params.diameter + id.x;
+    voxels[index] = inside;
+}

--- a/client/assets/shaders/visible_chunks.wgsl
+++ b/client/assets/shaders/visible_chunks.wgsl
@@ -1,0 +1,30 @@
+struct Params {
+    centre: vec3<i32>;
+    radius: i32;
+    count: u32;
+    _pad: u32;
+};
+
+@group(0) @binding(0)
+var<uniform> params: Params;
+
+@group(0) @binding(1)
+var<storage, read> keys_in: array<vec3<i32>>;
+
+@group(0) @binding(2)
+var<storage, read_write> results: array<vec4<i32>>;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    let idx = id.x;
+    if (idx >= params.count) { return; }
+    let key = keys_in[idx];
+    let dx = key.x - params.centre.x;
+    let dy = key.y - params.centre.y;
+    let dz = key.z - params.centre.z;
+    var dist2 = dx * dx + dy * dy + dz * dz;
+    if (abs(dx) > params.radius || abs(dy) > params.radius || abs(dz) > params.radius) {
+        dist2 = -1;
+    }
+    results[idx] = vec4<i32>(key, dist2);
+}

--- a/client/src/app.rs
+++ b/client/src/app.rs
@@ -1,5 +1,7 @@
 use bevy::pbr::wireframe::WireframePlugin;
 use crate::helper::debug_gizmos::debug_gizmos;
+use bevy_easy_compute::prelude::{AppComputePlugin, AppComputeWorkerPlugin};
+use crate::plugins::environment::systems::voxels::sphere_compute::SphereWorker;
 use bevy::prelude::*;
 pub struct AppPlugin;
 
@@ -8,6 +10,8 @@ impl Plugin for AppPlugin {
         app.add_plugins(crate::plugins::ui::ui_plugin::UiPlugin);
         app.add_plugins(crate::plugins::big_space::big_space_plugin::BigSpaceIntegrationPlugin);
         app.add_plugins(crate::plugins::environment::environment_plugin::EnvironmentPlugin);
+        app.add_plugins(AppComputePlugin);
+        app.add_plugins(AppComputeWorkerPlugin::<SphereWorker>::default());
         //app.add_plugins(crate::plugins::network::network_plugin::NetworkPlugin);
         app.add_plugins(crate::plugins::input::input_plugin::InputPlugin);
         app.add_plugins(WireframePlugin);

--- a/client/src/app.rs
+++ b/client/src/app.rs
@@ -2,6 +2,7 @@ use bevy::pbr::wireframe::WireframePlugin;
 use crate::helper::debug_gizmos::debug_gizmos;
 use bevy_easy_compute::prelude::{AppComputePlugin, AppComputeWorkerPlugin};
 use crate::plugins::environment::systems::voxels::sphere_compute::SphereWorker;
+use crate::plugins::environment::systems::voxels::visible_chunks_compute::VisibleChunksWorker;
 use bevy::prelude::*;
 pub struct AppPlugin;
 
@@ -12,6 +13,7 @@ impl Plugin for AppPlugin {
         app.add_plugins(crate::plugins::environment::environment_plugin::EnvironmentPlugin);
         app.add_plugins(AppComputePlugin);
         app.add_plugins(AppComputeWorkerPlugin::<SphereWorker>::default());
+        app.add_plugins(AppComputeWorkerPlugin::<VisibleChunksWorker>::default());
         //app.add_plugins(crate::plugins::network::network_plugin::NetworkPlugin);
         app.add_plugins(crate::plugins::input::input_plugin::InputPlugin);
         app.add_plugins(WireframePlugin);

--- a/client/src/app.rs
+++ b/client/src/app.rs
@@ -3,6 +3,7 @@ use crate::helper::debug_gizmos::debug_gizmos;
 use bevy_easy_compute::prelude::{AppComputePlugin, AppComputeWorkerPlugin};
 use crate::plugins::environment::systems::voxels::sphere_compute::SphereWorker;
 use crate::plugins::environment::systems::voxels::visible_chunks_compute::VisibleChunksWorker;
+use crate::plugins::environment::systems::voxels::chunk_mesh_compute::ChunkMeshWorker;
 use bevy::prelude::*;
 pub struct AppPlugin;
 
@@ -14,6 +15,7 @@ impl Plugin for AppPlugin {
         app.add_plugins(AppComputePlugin);
         app.add_plugins(AppComputeWorkerPlugin::<SphereWorker>::default());
         app.add_plugins(AppComputeWorkerPlugin::<VisibleChunksWorker>::default());
+        app.add_plugins(AppComputeWorkerPlugin::<ChunkMeshWorker>::default());
         //app.add_plugins(crate::plugins::network::network_plugin::NetworkPlugin);
         app.add_plugins(crate::plugins::input::input_plugin::InputPlugin);
         app.add_plugins(WireframePlugin);

--- a/client/src/app.rs
+++ b/client/src/app.rs
@@ -4,6 +4,7 @@ use bevy_easy_compute::prelude::{AppComputePlugin, AppComputeWorkerPlugin};
 use crate::plugins::environment::systems::voxels::sphere_compute::SphereWorker;
 use crate::plugins::environment::systems::voxels::visible_chunks_compute::VisibleChunksWorker;
 use crate::plugins::environment::systems::voxels::chunk_mesh_compute::ChunkMeshWorker;
+use crate::plugins::environment::systems::voxels::lod_compute::ChunkLodWorker;
 use bevy::prelude::*;
 pub struct AppPlugin;
 
@@ -16,6 +17,7 @@ impl Plugin for AppPlugin {
         app.add_plugins(AppComputeWorkerPlugin::<SphereWorker>::default());
         app.add_plugins(AppComputeWorkerPlugin::<VisibleChunksWorker>::default());
         app.add_plugins(AppComputeWorkerPlugin::<ChunkMeshWorker>::default());
+        app.add_plugins(AppComputeWorkerPlugin::<ChunkLodWorker>::default());
         //app.add_plugins(crate::plugins::network::network_plugin::NetworkPlugin);
         app.add_plugins(crate::plugins::input::input_plugin::InputPlugin);
         app.add_plugins(WireframePlugin);

--- a/client/src/plugins/environment/systems/voxel_system.rs
+++ b/client/src/plugins/environment/systems/voxel_system.rs
@@ -47,7 +47,7 @@ pub fn setup(
             generate_voxel_sphere_parallel(&mut tree, center, radius, color);
         }*/
         
-        generate_voxel_sphere(&mut tree, 200, color);
+        // voxel sphere is generated asynchronously via compute shader
         tree
     };
 

--- a/client/src/plugins/environment/systems/voxels/chunk_mesh_compute.rs
+++ b/client/src/plugins/environment/systems/voxels/chunk_mesh_compute.rs
@@ -1,0 +1,52 @@
+use bevy::prelude::*;
+use bevy_easy_compute::prelude::*;
+use bytemuck::{Pod, Zeroable};
+use super::structure::CHUNK_SIZE;
+
+const MAX_FACES: usize = (CHUNK_SIZE as usize) * (CHUNK_SIZE as usize) * (CHUNK_SIZE as usize) * 6;
+pub const MAX_VERTICES: usize = MAX_FACES * 4;
+pub const MAX_INDICES: usize = MAX_FACES * 6;
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable, ShaderType)]
+pub struct MeshParams {
+    pub origin: [f32; 3],
+    pub step: f32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable, ShaderType, Default)]
+pub struct MeshCounts {
+    pub vertex_count: u32,
+    pub index_count: u32,
+}
+
+#[derive(TypePath)]
+struct MeshShader;
+
+impl ComputeShader for MeshShader {
+    fn shader() -> ShaderRef {
+        "shaders/chunk_mesh.wgsl".into()
+    }
+}
+
+#[derive(Resource)]
+pub struct ChunkMeshWorker;
+
+impl ComputeWorker for ChunkMeshWorker {
+    fn build(world: &mut World) -> AppComputeWorker<Self> {
+        let params = MeshParams { origin: [0.0; 3], step: 1.0 };
+        AppComputeWorkerBuilder::new(world)
+            .add_uniform("params", &params)
+            .add_staging("voxels", &[0u32; CHUNK_SIZE as usize * CHUNK_SIZE as usize * CHUNK_SIZE as usize])
+            .add_staging("positions", &[[0.0_f32; 3]; MAX_VERTICES])
+            .add_staging("normals", &[[0.0_f32; 3]; MAX_VERTICES])
+            .add_staging("uvs", &[[0.0_f32; 2]; MAX_VERTICES])
+            .add_staging("indices", &[0u32; MAX_INDICES])
+            .add_staging("counts", &MeshCounts::default())
+            .add_pass::<MeshShader>([1, 1, 1], &["params", "voxels", "positions", "normals", "uvs", "indices", "counts"])
+            .one_shot()
+            .synchronous()
+            .build()
+    }
+}

--- a/client/src/plugins/environment/systems/voxels/lod.rs
+++ b/client/src/plugins/environment/systems/voxels/lod.rs
@@ -1,38 +1,60 @@
 use bevy::prelude::*;
-use crate::plugins::environment::systems::voxels::helper::chunk_center_world;
-use crate::plugins::environment::systems::voxels::structure::{Chunk, ChunkLod, ChunkCullingCfg, SparseVoxelOctree, CHUNK_SIZE};
+use crate::plugins::environment::systems::voxels::helper::world_to_chunk;
+use crate::plugins::environment::systems::voxels::structure::{Chunk, ChunkLod, ChunkCullingCfg, SparseVoxelOctree, ChunkKey};
+use super::lod_compute::{ChunkLodWorker, LodParams, MAX_LOD_CHUNKS};
+use super::visible_chunks_compute::IVec3Pod;
+use bevy_easy_compute::prelude::AppComputeWorker;
 
 /// Update each chunk's LOD level based on its distance from the camera.
 /// Chunks farther away get a higher LOD value (coarser mesh).
 pub fn update_chunk_lods(
     cam_q: Query<&GlobalTransform, With<Camera>>,
-    mut chunks: Query<(&Chunk, &mut ChunkLod)>,
+    chunks: Query<(Entity, &Chunk, &ChunkLod)>,
+    mut chunks_mut: Query<&mut ChunkLod>,
     mut tree_q: Query<&mut SparseVoxelOctree>,
+    mut worker: ResMut<AppComputeWorker<ChunkLodWorker>>,
     cfg: Res<ChunkCullingCfg>,
 ) {
     let cam_pos = cam_q.single().translation();
-
-    // Borrow the octree only once to avoid repeated query lookups
-    let mut tree = tree_q.single_mut();
+    let tree = tree_q.single();
     let max_depth = tree.max_depth - 1;
+    let max_level = max_depth;
     let range_step = cfg.view_distance_chunks as f32 / (max_depth as f32 - 1.0);
-    let chunk_size = CHUNK_SIZE as f32 * tree.get_spacing_at_depth(max_depth);
+    let centre = world_to_chunk(tree, cam_pos);
+    drop(tree);
 
-    let mut changed = Vec::new();
-    for (chunk, mut lod) in chunks.iter_mut() {
-        let center = chunk_center_world(&tree, chunk.key);
-        let dist_chunks = cam_pos.distance(center) / chunk_size;
-        let mut level = (dist_chunks / range_step).floor() as u32;
-        if level > max_depth {
-            level = max_depth;
-        }
-        if lod.0 != level {
-            lod.0 = level;
-            changed.push(chunk.key);
-        }
+    let mut keys: Vec<IVec3Pod> = Vec::new();
+    let mut entities: Vec<(Entity, ChunkKey)> = Vec::new();
+    for (ent, chunk, _lod) in chunks.iter() {
+        keys.push(IVec3Pod { x: chunk.key.0, y: chunk.key.1, z: chunk.key.2, _pad: 0 });
+        entities.push((ent, chunk.key));
     }
 
-    for key in changed {
-        tree.dirty_chunks.insert(key);
+    let count = keys.len().min(MAX_LOD_CHUNKS);
+    worker.write_slice("keys_in", &keys[..count]);
+    let params = LodParams {
+        centre: IVec3Pod { x: centre.0, y: centre.1, z: centre.2, _pad: 0 },
+        max_level,
+        count: count as u32,
+        range_step,
+        _pad0: 0,
+    };
+    worker.write("params", &params);
+    worker.execute();
+
+    if !worker.ready() {
+        return;
+    }
+
+    let results: Vec<u32> = worker.read_vec("lod_out");
+
+    let mut tree = tree_q.single_mut();
+    for ((ent, key), level) in entities.into_iter().zip(results.into_iter().take(count)) {
+        if let Ok(mut lod) = chunks_mut.get_mut(ent) {
+            if lod.0 != level {
+                lod.0 = level;
+                tree.dirty_chunks.insert(key);
+            }
+        }
     }
 }

--- a/client/src/plugins/environment/systems/voxels/lod_compute.rs
+++ b/client/src/plugins/environment/systems/voxels/lod_compute.rs
@@ -1,0 +1,49 @@
+use bevy::prelude::*;
+use bevy_easy_compute::prelude::*;
+use bytemuck::{Pod, Zeroable};
+
+use super::visible_chunks_compute::IVec3Pod;
+
+pub const MAX_LOD_CHUNKS: usize = 4096;
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable, ShaderType)]
+pub struct LodParams {
+    pub centre: IVec3Pod,
+    pub max_level: u32,
+    pub count: u32,
+    pub range_step: f32,
+    pub _pad0: u32,
+}
+
+#[derive(TypePath)]
+struct LodShader;
+
+impl ComputeShader for LodShader {
+    fn shader() -> ShaderRef {
+        "shaders/chunk_lod.wgsl".into()
+    }
+}
+
+#[derive(Resource)]
+pub struct ChunkLodWorker;
+
+impl ComputeWorker for ChunkLodWorker {
+    fn build(world: &mut World) -> AppComputeWorker<Self> {
+        let params = LodParams {
+            centre: IVec3Pod { x: 0, y: 0, z: 0, _pad: 0 },
+            max_level: 0,
+            count: 0,
+            range_step: 1.0,
+            _pad0: 0,
+        };
+        AppComputeWorkerBuilder::new(world)
+            .add_uniform("params", &params)
+            .add_staging("keys_in", &[IVec3Pod { x: 0, y: 0, z: 0, _pad: 0 }; MAX_LOD_CHUNKS])
+            .add_staging("lod_out", &[0u32; MAX_LOD_CHUNKS])
+            .add_pass::<LodShader>([((MAX_LOD_CHUNKS as u32 + 63) / 64), 1, 1], &["params", "keys_in", "lod_out"])
+            .one_shot()
+            .synchronous()
+            .build()
+    }
+}

--- a/client/src/plugins/environment/systems/voxels/mod.rs
+++ b/client/src/plugins/environment/systems/voxels/mod.rs
@@ -11,3 +11,4 @@ pub mod queue_systems;
 pub mod lod;
 pub mod noise_compute;
 pub mod sphere_compute;
+pub mod visible_chunks_compute;

--- a/client/src/plugins/environment/systems/voxels/mod.rs
+++ b/client/src/plugins/environment/systems/voxels/mod.rs
@@ -12,3 +12,4 @@ pub mod lod;
 pub mod noise_compute;
 pub mod sphere_compute;
 pub mod visible_chunks_compute;
+pub mod chunk_mesh_compute;

--- a/client/src/plugins/environment/systems/voxels/mod.rs
+++ b/client/src/plugins/environment/systems/voxels/mod.rs
@@ -9,3 +9,5 @@ pub mod render_chunks;
 pub mod culling;
 pub mod queue_systems;
 pub mod lod;
+pub mod noise_compute;
+pub mod sphere_compute;

--- a/client/src/plugins/environment/systems/voxels/mod.rs
+++ b/client/src/plugins/environment/systems/voxels/mod.rs
@@ -13,3 +13,4 @@ pub mod noise_compute;
 pub mod sphere_compute;
 pub mod visible_chunks_compute;
 pub mod chunk_mesh_compute;
+pub mod lod_compute;

--- a/client/src/plugins/environment/systems/voxels/noise_compute.rs
+++ b/client/src/plugins/environment/systems/voxels/noise_compute.rs
@@ -1,6 +1,7 @@
 use bevy::prelude::*;
 use bevy_easy_compute::prelude::*;
 
+#[repr(C)]
 #[derive(ShaderType, Clone, Copy)]
 pub struct NoiseParams {
     pub frequency: f32,

--- a/client/src/plugins/environment/systems/voxels/noise_compute.rs
+++ b/client/src/plugins/environment/systems/voxels/noise_compute.rs
@@ -1,0 +1,41 @@
+use bevy::prelude::*;
+use bevy_easy_compute::prelude::*;
+
+#[derive(ShaderType, Clone, Copy)]
+pub struct NoiseParams {
+    pub frequency: f32,
+    pub amplitude: f32,
+    pub width: u32,
+    pub depth: u32,
+}
+
+#[derive(TypePath)]
+struct NoiseShader;
+
+impl ComputeShader for NoiseShader {
+    fn shader() -> ShaderRef {
+        "shaders/noise.wgsl".into()
+    }
+}
+
+#[derive(Resource)]
+pub struct NoiseWorker;
+
+impl ComputeWorker for NoiseWorker {
+    fn build(world: &mut World) -> AppComputeWorker<Self> {
+        let params = NoiseParams {
+            frequency: 0.1,
+            amplitude: 1.0,
+            width: 0,
+            depth: 0,
+        };
+
+        AppComputeWorkerBuilder::new(world)
+            .add_uniform("params", &params)
+            .add_staging("heights", &[0.0_f32; 1])
+            .add_pass::<NoiseShader>([1, 1, 1], &["params", "heights"])
+            .one_shot()
+            .build()
+    }
+}
+

--- a/client/src/plugins/environment/systems/voxels/queue_systems.rs
+++ b/client/src/plugins/environment/systems/voxels/queue_systems.rs
@@ -1,51 +1,51 @@
 use bevy::prelude::*;
 use crate::plugins::environment::systems::voxels::helper::world_to_chunk;
 use crate::plugins::environment::systems::voxels::structure::*;
+use crate::plugins::environment::systems::voxels::visible_chunks_compute::{
+    VisibleChunksWorker, VisibleParams, IVec3Pod, ChunkResult, VisibleChunkCount,
+    MAX_VISIBLE_CHUNKS,
+};
+use bevy_easy_compute::prelude::*;
 
 
 
 /// enqueue chunks that *should* be visible but are not yet spawned
 /// enqueue chunks that *should* be visible but are not yet spawned
 pub fn enqueue_visible_chunks(
-    mut queue      : ResMut<ChunkQueue>,
-    spawned        : Res<SpawnedChunks>,
     mut prev_cam   : ResMut<PrevCameraChunk>,
     cfg            : Res<ChunkCullingCfg>,
     cam_q          : Query<&GlobalTransform, With<Camera>>,
     tree_q         : Query<&SparseVoxelOctree>,
+    mut worker     : ResMut<AppComputeWorker<VisibleChunksWorker>>,
+    mut count_res  : ResMut<VisibleChunkCount>,
 ) {
-    let tree     = tree_q.single();
-    let cam_pos  = cam_q.single().translation();
-    let centre   = world_to_chunk(tree, cam_pos);
+    let tree    = tree_q.single();
+    let cam_pos = cam_q.single().translation();
+    let centre  = world_to_chunk(tree, cam_pos);
 
     if prev_cam.0 == Some(centre) {
         return;
     }
     prev_cam.0 = Some(centre);
 
-    let r = cfg.view_distance_chunks;
-
-    let mut keys: Vec<(ChunkKey, i32)> = tree
+    let keys: Vec<IVec3Pod> = tree
         .occupied_chunks
         .iter()
-        .filter_map(|key| {
-            let dx = key.0 - centre.0;
-            let dy = key.1 - centre.1;
-            let dz = key.2 - centre.2;
-            if dx.abs() > r || dy.abs() > r || dz.abs() > r { return None; }
-            if spawned.0.contains_key(key) { return None; }
-            Some((*key, dx*dx + dy*dy + dz*dz))
-        })
+        .map(|k| IVec3Pod { x: k.0, y: k.1, z: k.2, _pad: 0 })
         .collect();
 
-    keys.sort_by_key(|(_, d)| *d);
+    let count = keys.len().min(MAX_VISIBLE_CHUNKS);
+    worker.write_slice("keys_in", &keys[..count]);
 
-    queue.keys.clear();
-    queue.set.clear();
-    for (key, _) in keys {
-        queue.keys.push_back(key);
-        queue.set.insert(key);
-    }
+    let params = VisibleParams {
+        centre: IVec3Pod { x: centre.0, y: centre.1, z: centre.2, _pad: 0 },
+        radius: cfg.view_distance_chunks,
+        count: count as u32,
+        _pad0: 0,
+    };
+    worker.write("params", &params);
+    worker.execute();
+    count_res.0 = count;
 }
 
 /// move a limited number of keys from the queue into the octree’s dirty set
@@ -60,5 +60,36 @@ pub fn process_chunk_queue(
             queue.set.remove(&key);
             tree.dirty_chunks.insert(key);
         } else { break; }
+    }
+}
+
+pub fn apply_visible_chunk_results(
+    mut worker    : ResMut<AppComputeWorker<VisibleChunksWorker>>,
+    mut queue     : ResMut<ChunkQueue>,
+    spawned       : Res<SpawnedChunks>,
+    count_res     : Res<VisibleChunkCount>,
+) {
+    if !worker.ready() {
+        return;
+    }
+
+    let mut results: Vec<ChunkResult> = worker.read_vec("results");
+    results.truncate(count_res.0);
+    let mut keys: Vec<(ChunkKey, i32)> = results
+        .into_iter()
+        .filter_map(|r| {
+            if r.dist2 < 0 { return None; }
+            let key = (r.key.x, r.key.y, r.key.z);
+            if spawned.0.contains_key(&key) { return None; }
+            Some((key, r.dist2))
+        })
+        .collect();
+    keys.sort_by_key(|(_, d)| *d);
+
+    queue.keys.clear();
+    queue.set.clear();
+    for (key, _) in keys {
+        queue.keys.push_back(key);
+        queue.set.insert(key);
     }
 }

--- a/client/src/plugins/environment/systems/voxels/queue_systems.rs
+++ b/client/src/plugins/environment/systems/voxels/queue_systems.rs
@@ -79,7 +79,7 @@ pub fn apply_visible_chunk_results(
         .into_iter()
         .filter_map(|r| {
             if r.dist2 < 0 { return None; }
-            let key = (r.key.x, r.key.y, r.key.z);
+            let key = ChunkKey(r.key.x, r.key.y, r.key.z);
             if spawned.0.contains_key(&key) { return None; }
             Some((key, r.dist2))
         })

--- a/client/src/plugins/environment/systems/voxels/queue_systems.rs
+++ b/client/src/plugins/environment/systems/voxels/queue_systems.rs
@@ -79,7 +79,7 @@ pub fn apply_visible_chunk_results(
         .into_iter()
         .filter_map(|r| {
             if r.dist2 < 0 { return None; }
-            let key = ChunkKey(r.key.x, r.key.y, r.key.z);
+            let key = ChunkKey(r.x, r.y, r.z);
             if spawned.0.contains_key(&key) { return None; }
             Some((key, r.dist2))
         })

--- a/client/src/plugins/environment/systems/voxels/render_chunks.rs
+++ b/client/src/plugins/environment/systems/voxels/render_chunks.rs
@@ -2,8 +2,9 @@ use std::collections::HashMap;
 use bevy::pbr::wireframe::Wireframe;
 use bevy::prelude::*;
 use bevy::render::mesh::{
-    Mesh, PrimitiveTopology, Indices, VertexAttributeValues, RenderAssetUsages,
+    Mesh, PrimitiveTopology, Indices, VertexAttributeValues,
 };
+use bevy::asset::RenderAssetUsages;
 use big_space::prelude::GridCell;
 use crate::plugins::big_space::big_space_plugin::RootGrid;
 use crate::plugins::environment::systems::voxels::chunk_mesh_compute::{

--- a/client/src/plugins/environment/systems/voxels/sphere_compute.rs
+++ b/client/src/plugins/environment/systems/voxels/sphere_compute.rs
@@ -1,0 +1,90 @@
+use bevy::prelude::*;
+use bevy_easy_compute::prelude::*;
+use bytemuck::{Pod, Zeroable};
+use super::structure::{SparseVoxelOctree, Voxel};
+
+#[repr(C)]
+#[derive(ShaderType, Clone, Copy, Pod, Zeroable)]
+pub struct SphereParams {
+    pub radius: u32,
+    pub diameter: u32,
+}
+
+#[derive(TypePath)]
+struct SphereShader;
+
+impl ComputeShader for SphereShader {
+    fn shader() -> ShaderRef {
+        "shaders/sphere.wgsl".into()
+    }
+}
+
+#[derive(Resource)]
+pub struct SphereWorker;
+
+impl ComputeWorker for SphereWorker {
+    fn build(world: &mut World) -> AppComputeWorker<Self> {
+        let radius = 200u32;
+        let diameter = radius * 2 + 1;
+        let params = SphereParams { radius, diameter };
+        let buffer = vec![0u32; (diameter * diameter * diameter) as usize];
+
+        AppComputeWorkerBuilder::new(world)
+            .add_uniform("params", &params)
+            .add_staging("voxels", &buffer)
+            .add_pass::<SphereShader>([
+                (diameter + 7) / 8,
+                (diameter + 7) / 8,
+                (diameter + 7) / 8,
+            ], &["params", "voxels"])
+            .synchronous()
+            .one_shot()
+            .build()
+    }
+}
+
+#[derive(Resource, Default)]
+pub struct SphereGenerated(pub bool);
+
+pub fn execute_sphere_once(
+    mut worker: ResMut<AppComputeWorker<SphereWorker>>,
+    mut generated: ResMut<SphereGenerated>,
+) {
+    if generated.0 {
+        return;
+    }
+    worker.execute();
+    generated.0 = true;
+}
+
+pub fn apply_sphere_result(
+    mut worker: ResMut<AppComputeWorker<SphereWorker>>,
+    mut octree_q: Query<&mut SparseVoxelOctree>,
+    mut generated: ResMut<SphereGenerated>,
+) {
+    if !generated.0 || !worker.ready() {
+        return;
+    }
+
+    let params: SphereParams = worker.read("params");
+    let voxels: Vec<u32> = worker.read_vec("voxels");
+    let mut octree = octree_q.single_mut();
+    let step = octree.get_spacing_at_depth(octree.max_depth);
+    let radius = params.radius as i32;
+    let diameter = params.diameter as i32;
+    for x in 0..diameter {
+        for y in 0..diameter {
+            for z in 0..diameter {
+                let idx = (z * diameter * diameter + y * diameter + x) as usize;
+                if voxels[idx] != 0 {
+                    let wx = (x - radius) as f32 * step;
+                    let wy = (y - radius) as f32 * step;
+                    let wz = (z - radius) as f32 * step;
+                    octree.insert(Vec3::new(wx, wy, wz), Voxel { color: Color::rgb(0.2, 0.8, 0.2) });
+                }
+            }
+        }
+    }
+    generated.0 = false;
+}
+

--- a/client/src/plugins/environment/systems/voxels/visible_chunks_compute.rs
+++ b/client/src/plugins/environment/systems/voxels/visible_chunks_compute.rs
@@ -25,7 +25,9 @@ pub struct VisibleParams {
 #[repr(C)]
 #[derive(Clone, Copy, Pod, Zeroable, ShaderType)]
 pub struct ChunkResult {
-    pub key: IVec3Pod,
+    pub x: i32,
+    pub y: i32,
+    pub z: i32,
     pub dist2: i32,
 }
 
@@ -52,7 +54,7 @@ impl ComputeWorker for VisibleChunksWorker {
         AppComputeWorkerBuilder::new(world)
             .add_uniform("params", &default_params)
             .add_staging("keys_in", &[IVec3Pod { x: 0, y: 0, z: 0, _pad: 0 }; MAX_VISIBLE_CHUNKS])
-            .add_staging("results", &[ChunkResult { key: IVec3Pod { x: 0, y: 0, z: 0, _pad: 0 }, dist2: 0 }; MAX_VISIBLE_CHUNKS])
+            .add_staging("results", &[ChunkResult { x: 0, y: 0, z: 0, dist2: 0 }; MAX_VISIBLE_CHUNKS])
             .add_pass::<VisibleShader>([((MAX_VISIBLE_CHUNKS as u32 + 63) / 64), 1, 1], &["params", "keys_in", "results"])
             .one_shot()
             .synchronous()

--- a/client/src/plugins/environment/systems/voxels/visible_chunks_compute.rs
+++ b/client/src/plugins/environment/systems/voxels/visible_chunks_compute.rs
@@ -1,0 +1,64 @@
+use bevy::prelude::*;
+use bevy_easy_compute::prelude::*;
+use bytemuck::{Pod, Zeroable};
+
+pub const MAX_VISIBLE_CHUNKS: usize = 4096;
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable, ShaderType)]
+pub struct IVec3Pod {
+    pub x: i32,
+    pub y: i32,
+    pub z: i32,
+    pub _pad: i32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable, ShaderType)]
+pub struct VisibleParams {
+    pub centre: IVec3Pod,
+    pub radius: i32,
+    pub count: u32,
+    pub _pad0: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+pub struct ChunkResult {
+    pub key: IVec3Pod,
+    pub dist2: i32,
+}
+
+#[derive(TypePath)]
+struct VisibleShader;
+
+impl ComputeShader for VisibleShader {
+    fn shader() -> ShaderRef {
+        "shaders/visible_chunks.wgsl".into()
+    }
+}
+
+#[derive(Resource)]
+pub struct VisibleChunksWorker;
+
+impl ComputeWorker for VisibleChunksWorker {
+    fn build(world: &mut World) -> AppComputeWorker<Self> {
+        let default_params = VisibleParams {
+            centre: IVec3Pod { x: 0, y: 0, z: 0, _pad: 0 },
+            radius: 0,
+            count: 0,
+            _pad0: 0,
+        };
+        AppComputeWorkerBuilder::new(world)
+            .add_uniform("params", &default_params)
+            .add_staging("keys_in", &[IVec3Pod { x: 0, y: 0, z: 0, _pad: 0 }; MAX_VISIBLE_CHUNKS])
+            .add_staging("results", &[ChunkResult { key: IVec3Pod { x: 0, y: 0, z: 0, _pad: 0 }, dist2: 0 }; MAX_VISIBLE_CHUNKS])
+            .add_pass::<VisibleShader>([((MAX_VISIBLE_CHUNKS as u32 + 63) / 64), 1, 1], &["params", "keys_in", "results"])
+            .one_shot()
+            .synchronous()
+            .build()
+    }
+}
+
+#[derive(Resource, Default)]
+pub struct VisibleChunkCount(pub usize);

--- a/client/src/plugins/environment/systems/voxels/visible_chunks_compute.rs
+++ b/client/src/plugins/environment/systems/voxels/visible_chunks_compute.rs
@@ -23,7 +23,7 @@ pub struct VisibleParams {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Pod, Zeroable)]
+#[derive(Clone, Copy, Pod, Zeroable, ShaderType)]
 pub struct ChunkResult {
     pub key: IVec3Pod,
     pub dist2: i32,


### PR DESCRIPTION
## Summary
- integrate `bevy_easy_compute` for compute shaders
- add compute worker for generating voxel spheres on the GPU
- include WGSL shaders for noise and sphere generation
- register compute plugins in the main app

## Testing
- `cargo check`
- `cargo test` *(fails: Tracy profiler missing)*

------
https://chatgpt.com/codex/tasks/task_e_684951e7fd208326ae7d928e12838b3c