### PR TITLE
Update to Bevy 0.16.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,22 @@
 [workspace]
 resolver = "2"
 members = ["client"]
+
+[patch.crates-io]
+bevy = { git = "https://github.com/bevyengine/bevy.git", tag = "v0.16.1" }
+bevy_app = { git = "https://github.com/bevyengine/bevy.git", tag = "v0.16.1" }
+bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", tag = "v0.16.1" }
+bevy_log = { git = "https://github.com/bevyengine/bevy.git", tag = "v0.16.1" }
+bevy_math = { git = "https://github.com/bevyengine/bevy.git", tag = "v0.16.1" }
+bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", tag = "v0.16.1" }
+bevy_tasks = { git = "https://github.com/bevyengine/bevy.git", tag = "v0.16.1" }
+bevy_transform = { git = "https://github.com/bevyengine/bevy.git", tag = "v0.16.1" }
+bevy_utils = { git = "https://github.com/bevyengine/bevy.git", tag = "v0.16.1" }
+bevy_platform = { git = "https://github.com/bevyengine/bevy.git", tag = "v0.16.1" }
+bevy_color = { git = "https://github.com/bevyengine/bevy.git", tag = "v0.16.1" }
+bevy_gizmos = { git = "https://github.com/bevyengine/bevy.git", tag = "v0.16.1" }
+bevy_render = { git = "https://github.com/bevyengine/bevy.git", tag = "v0.16.1" }
+bevy_input = { git = "https://github.com/bevyengine/bevy.git", tag = "v0.16.1" }
+bevy_time = { git = "https://github.com/bevyengine/bevy.git", tag = "v0.16.1" }
+bevy_window = { git = "https://github.com/bevyengine/bevy.git", tag = "v0.16.1" }
+

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,7 +9,7 @@ build = "build.rs"
 
 
 [dependencies]
-bevy = { version = "0.15.1", features = ["jpeg", "trace_tracy", "trace_tracy_memory", "serialize"] }
+bevy = { version = "0.16.1", features = ["jpeg", "trace_tracy", "trace_tracy_memory", "serialize"] }
 rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -13,7 +13,7 @@ bevy = { version = "0.16.1", features = ["jpeg", "trace_tracy", "trace_tracy_mem
 rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
-big_space = "0.9.1"
+big_space = { git = "https://github.com/aevyrie/big_space.git", rev = "5345af11d4ce138bacf5a9a3ab53d1c3b3b103c7" }
 noise = "0.9.0"
 itertools = "0.13.0"
 bitvec = "1.0.1"

--- a/client/src/app.rs
+++ b/client/src/app.rs
@@ -10,7 +10,7 @@ impl Plugin for AppPlugin {
         app.add_plugins(crate::plugins::environment::environment_plugin::EnvironmentPlugin);
         //app.add_plugins(crate::plugins::network::network_plugin::NetworkPlugin);
         app.add_plugins(crate::plugins::input::input_plugin::InputPlugin);
-        app.add_plugins(WireframePlugin);
+        app.add_plugins(WireframePlugin::default());
 
         app.add_systems(Update, (debug_gizmos));
         app.register_type::<Option<Handle<Image>>>();

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -13,7 +13,7 @@ use bevy::render::RenderPlugin;
 use bevy::DefaultPlugins;
 use bevy::input::gamepad::AxisSettingsError::DeadZoneUpperBoundGreaterThanLiveZoneUpperBound;
 use bevy::window::PresentMode;
-use big_space::plugin::BigSpacePlugin;
+use big_space::plugin::BigSpaceDefaultPlugins;
 use toml;
 use crate::config::Config;
 use crate::plugins::big_space::big_space_plugin::BigSpaceIntegrationPlugin;

--- a/client/src/plugins/big_space/big_space_plugin.rs
+++ b/client/src/plugins/big_space/big_space_plugin.rs
@@ -16,7 +16,7 @@ pub struct RootGrid(pub Entity);
 
 impl Plugin for BigSpaceIntegrationPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(BigSpacePlugin::<i64>::default());
+        app.add_plugins(BigSpaceDefaultPlugins);
 
         app.add_systems(PreStartup, (spawn_root, cache_root.after(spawn_root)));
         app.add_systems(PostStartup, (fix_invalid_children));
@@ -27,7 +27,7 @@ impl Plugin for BigSpaceIntegrationPlugin {
 
 // 1) build the Big-Space root
 fn spawn_root(mut commands: Commands) {
-    commands.spawn_big_space_default::<i64>(|_| {});
+    commands.spawn_big_space_default(|_| {});
 }
 
 // 2) cache the root entity for later use
@@ -44,10 +44,10 @@ fn cache_root(
 
 fn fix_invalid_children(
     mut commands: Commands,
-    bad: Query<Entity, (With<FloatingOrigin>, Without<GridCell<i64>>, With<ChildOf>)>,
+    bad: Query<Entity, (With<FloatingOrigin>, Without<GridCell>, With<ChildOf>)>,
 ) {
     for e in &bad {
-        commands.entity(e).insert(GridCell::<i64>::ZERO);
+        commands.entity(e).insert(GridCell::ZERO);
     }
 }
 
@@ -63,11 +63,11 @@ pub fn move_by(
 
 
 
-pub fn teleport_to<P: GridPrecision>(
+pub fn teleport_to(
     e: Entity,
     target: DVec3,
-    grids: Grids<'_, '_, P>,
-    mut q: Query<(&ChildOf, &mut GridCell<P>, &mut Transform)>,
+    grids: Grids<'_, '_>,
+    mut q: Query<(&ChildOf, &mut GridCell, &mut Transform)>,
 ) {
     let (child_of, mut cell, mut tf) = q.get_mut(e).unwrap();
     let grid = grids.parent_grid(child_of.parent()).unwrap();

--- a/client/src/plugins/big_space/big_space_plugin.rs
+++ b/client/src/plugins/big_space/big_space_plugin.rs
@@ -1,5 +1,7 @@
 use bevy::math::DVec3;
 use bevy::prelude::*;
+use bevy::ecs::prelude::ChildOf;
+
 use big_space::prelude::*;
 
 /// Plugin enabling high precision coordinates using `big_space`.
@@ -31,7 +33,7 @@ fn spawn_root(mut commands: Commands) {
 // 2) cache the root entity for later use
 fn cache_root(
     mut commands: Commands,
-    roots: Query<Entity, (With<BigSpace>, Without<Parent>)>,   // top-level grid
+    roots: Query<Entity, (With<BigSpace>, Without<ChildOf>)>,   // top-level grid
 ) {
     if let Ok(entity) = roots.get_single() {
 
@@ -42,7 +44,7 @@ fn cache_root(
 
 fn fix_invalid_children(
     mut commands: Commands,
-    bad: Query<Entity, (With<FloatingOrigin>, Without<GridCell<i64>>, With<Parent>)>,
+    bad: Query<Entity, (With<FloatingOrigin>, Without<GridCell<i64>>, With<ChildOf>)>,
 ) {
     for e in &bad {
         commands.entity(e).insert(GridCell::<i64>::ZERO);
@@ -65,10 +67,10 @@ pub fn teleport_to<P: GridPrecision>(
     e: Entity,
     target: DVec3,
     grids: Grids<'_, '_, P>,
-    mut q: Query<(&Parent, &mut GridCell<P>, &mut Transform)>,
+    mut q: Query<(&ChildOf, &mut GridCell<P>, &mut Transform)>,
 ) {
-    let (parent, mut cell, mut tf) = q.get_mut(e).unwrap();
-    let grid = grids.parent_grid(parent.get()).unwrap();
+    let (child_of, mut cell, mut tf) = q.get_mut(e).unwrap();
+    let grid = grids.parent_grid(child_of.parent()).unwrap();
 
     let (new_cell, local) = grid.translation_to_grid(target);
 

--- a/client/src/plugins/environment/environment_plugin.rs
+++ b/client/src/plugins/environment/environment_plugin.rs
@@ -64,10 +64,12 @@ fn log_mesh_count(meshes: Res<Assets<Mesh>>, time: Res<Time>) {
     }
 }
 
-fn should_visualize_octree(octree_query: Query<&SparseVoxelOctree>,) -> bool {
-    octree_query.single().show_wireframe
+fn should_visualize_octree(octree_query: Query<&SparseVoxelOctree>) -> bool {
+    let Ok(octree) = octree_query.get_single() else { return false };
+    octree.show_wireframe
 }
 
-fn should_draw_grid(octree_query: Query<&SparseVoxelOctree>,) -> bool {
-    octree_query.single().show_world_grid
+fn should_draw_grid(octree_query: Query<&SparseVoxelOctree>) -> bool {
+    let Ok(octree) = octree_query.get_single() else { return false };
+    octree.show_world_grid
 }

--- a/client/src/plugins/environment/systems/environment_system.rs
+++ b/client/src/plugins/environment/systems/environment_system.rs
@@ -21,21 +21,21 @@ pub(crate) fn setup(
         ..default()
     });
 
-    // light (unchanged)
+    // light
     commands.entity(root.0).with_children(|p| {
-        p.spawn(DirectionalLightBundle {
-            transform: Transform::from_rotation(Quat::from_euler(
+        p.spawn((
+            Transform::from_rotation(Quat::from_euler(
                 EulerRot::XYZ,
                 -std::f32::consts::FRAC_PI_4,
                 0.0,
                 0.0,
             )),
-            directional_light: DirectionalLight {
+            GlobalTransform::default(),
+            DirectionalLight {
                 shadows_enabled: true,
                 ..default()
             },
-            ..default()
-        });
+        ));
     });
 
     /*// ---------- spawn spheres from football-size up to Earth-size ----------
@@ -59,7 +59,7 @@ pub(crate) fn setup(
 
             parent.spawn((
                 // spatial requirements for big_space
-                GridCell::<i64>::ZERO,
+                GridCell::ZERO,
                 Transform::from_scale(scale_v3).with_translation(pos),
                 GlobalTransform::default(),
                 // rendering

--- a/client/src/plugins/environment/systems/planet_system.rs
+++ b/client/src/plugins/environment/systems/planet_system.rs
@@ -36,7 +36,7 @@ pub fn setup(
             Name::new("Planet"),
             Mesh3d(sphere_mesh.clone()),
             MeshMaterial3d(material_handle),
-            GridCell::<i64>::ZERO,
+            GridCell::ZERO,
             Transform::default(),
             PlanetMaker,
             Wireframe,

--- a/client/src/plugins/environment/systems/planet_system.rs
+++ b/client/src/plugins/environment/systems/planet_system.rs
@@ -29,7 +29,7 @@ pub fn setup(
         SphereMeshBuilder::new(radius, SphereKind::Ico { subdivisions: 100 })
             .build(),
     );
-    let material_handle = materials.add(StandardMaterial::from(Color::rgb(0.3, 0.6, 1.0)));
+    let material_handle = materials.add(StandardMaterial::from(Color::srgb(0.3, 0.6, 1.0)));
 
     commands.entity(root.0).with_children(|parent| {
         parent.spawn((

--- a/client/src/plugins/environment/systems/voxel_system.rs
+++ b/client/src/plugins/environment/systems/voxel_system.rs
@@ -30,10 +30,10 @@ pub fn setup(
         }
     } else {
         let mut tree = SparseVoxelOctree::new(octree_depth, octree_base_size, false, false, false);
-        let color = Color::rgb(0.2, 0.8, 0.2);
+        let color = Color::srgb(0.2, 0.8, 0.2);
         // How many random spheres?
         /*const NUM_SPHERES: usize = 5;
-        let mut rng = thread_rng();
+        let mut rng = threald_rng();
 
         for _ in 0..NUM_SPHERES {
             let center = Vec3::new(

--- a/client/src/plugins/environment/systems/voxels/culling.rs
+++ b/client/src/plugins/environment/systems/voxels/culling.rs
@@ -20,8 +20,9 @@ pub fn despawn_distant_chunks(
     mut materials: ResMut<Assets<StandardMaterial>>,
     cfg          : Res<ChunkCullingCfg>,
 ) {
-    let tree   = tree_q.single();
-    let cam    = cam_q.single().translation();
+    let Ok(tree) = tree_q.get_single() else { return };
+    let Ok(cam_tf) = cam_q.get_single() else { return };
+    let cam    = cam_tf.translation();
     let centre = world_to_chunk(tree, cam);
 
     for (ent, chunk, mesh3d, mat3d) in chunk_q.iter() {

--- a/client/src/plugins/environment/systems/voxels/debug.rs
+++ b/client/src/plugins/environment/systems/voxels/debug.rs
@@ -100,7 +100,7 @@ pub fn draw_grid(
     camera_query: Query<&Transform, With<Camera>>,
     octree_query: Query<(&SparseVoxelOctree, &Transform)>,
 ) {
-    let camera_tf = camera_query.single();
+    let Ok(camera_tf) = camera_query.get_single() else { return };
     let camera_pos = camera_tf.translation;
 
     for (octree, octree_tf) in octree_query.iter() {

--- a/client/src/plugins/environment/systems/voxels/debug.rs
+++ b/client/src/plugins/environment/systems/voxels/debug.rs
@@ -15,7 +15,7 @@ pub fn visualize_octree_system(
         gizmos.cuboid(
             Transform::from_translation(octree_tf.translation)
                 .with_scale(Vec3::splat(octree.size)),
-            Color::rgba(1.0, 1.0, 0.0, 0.15),
+            Color::srgba(1.0, 1.0, 0.0, 0.15),
         );
 
         // Recursively draw children:
@@ -62,7 +62,7 @@ fn visualize_recursive_center(
             // Draw the child bounding box
             gizmos.cuboid(
                 Transform::from_translation(child_center).with_scale(Vec3::splat(child_size)),
-                Color::rgba(0.5, 1.0, 0.5, 0.15), // greenish
+                Color::srgba(0.5, 1.0, 0.5, 0.15), // greenish
             );
 
             // Recurse

--- a/client/src/plugins/environment/systems/voxels/lod.rs
+++ b/client/src/plugins/environment/systems/voxels/lod.rs
@@ -10,10 +10,11 @@ pub fn update_chunk_lods(
     mut tree_q: Query<&mut SparseVoxelOctree>,
     cfg: Res<ChunkCullingCfg>,
 ) {
-    let cam_pos = cam_q.single().translation();
+    let Ok(cam_tf) = cam_q.get_single() else { return };
+    let cam_pos = cam_tf.translation();
 
     // Borrow the octree only once to avoid repeated query lookups
-    let mut tree = tree_q.single_mut();
+    let Ok(mut tree) = tree_q.get_single_mut() else { return };
     let max_depth = tree.max_depth - 1;
     let range_step = cfg.view_distance_chunks as f32 / (max_depth as f32 - 1.0);
     let chunk_size = CHUNK_SIZE as f32 * tree.get_spacing_at_depth(max_depth);

--- a/client/src/plugins/environment/systems/voxels/queue_systems.rs
+++ b/client/src/plugins/environment/systems/voxels/queue_systems.rs
@@ -14,8 +14,9 @@ pub fn enqueue_visible_chunks(
     cam_q          : Query<&GlobalTransform, With<Camera>>,
     tree_q         : Query<&SparseVoxelOctree>,
 ) {
-    let tree     = tree_q.single();
-    let cam_pos  = cam_q.single().translation();
+    let Ok(tree)     = tree_q.get_single() else { return };
+    let Ok(cam_tf)  = cam_q.get_single() else { return };
+    let cam_pos  = cam_tf.translation();
     let centre   = world_to_chunk(tree, cam_pos);
 
     if prev_cam.0 == Some(centre) {
@@ -54,7 +55,7 @@ pub fn process_chunk_queue(
     budget      : Res<ChunkBudget>,
     mut tree_q  : Query<&mut SparseVoxelOctree>,
 ) {
-    let mut tree = tree_q.single_mut();
+    let Ok(mut tree) = tree_q.get_single_mut() else { return };
     for _ in 0..budget.per_frame {
         if let Some(key) = queue.keys.pop_front() {
             queue.set.remove(&key);

--- a/client/src/plugins/environment/systems/voxels/render_chunks.rs
+++ b/client/src/plugins/environment/systems/voxels/render_chunks.rs
@@ -109,7 +109,7 @@ pub fn rebuild_dirty_chunks(
                             Mesh3d::from(mesh_h.clone()),
                             MeshMaterial3d(mat_h.clone()),
                             Transform::default(),
-                            GridCell::<i64>::ZERO,
+                            GridCell::ZERO,
                             Chunk { key, voxels: Vec::new(), dirty: false },
                             ChunkLod(lod),
                             /*Wireframe,*/

--- a/client/src/plugins/input/input_plugin.rs
+++ b/client/src/plugins/input/input_plugin.rs
@@ -1,6 +1,7 @@
 
 use bevy::app::{App, Plugin, PreUpdate, Startup};
-use bevy::prelude::{IntoSystemConfigs, Update};
+use bevy::ecs::schedule::IntoScheduleConfigs;
+use bevy::prelude::Update;
 
 pub struct InputPlugin;
 impl Plugin for InputPlugin {

--- a/client/src/plugins/input/systems/flight.rs
+++ b/client/src/plugins/input/systems/flight.rs
@@ -37,9 +37,9 @@ pub fn flight_systems(
     // 1) Rotation & speed input (borrow transform/controller)
     //------------------------------------------------------------
     let delta_vec3 = {
-        let mut window     = windows.single_mut();
-        let mut transform  = xforms.single_mut();
-        let mut controller = ctrls.single_mut();
+        let Ok(mut window)     = windows.get_single_mut() else { return };
+        let Ok(mut transform)  = xforms.get_single_mut() else { return };
+        let Ok(mut controller) = ctrls.get_single_mut() else { return };
 
         //------------------ mouse look --------------------------
         if !window.cursor_options.visible {

--- a/client/src/plugins/input/systems/ui.rs
+++ b/client/src/plugins/input/systems/ui.rs
@@ -8,7 +8,7 @@ pub fn ui_system(
     mut app_exit_events: EventWriter<AppExit>,
     mut windows: Query<&mut Window>,
 ) {
-    let mut window = windows.single_mut();
+    let Ok(mut window) = windows.get_single_mut() else { return };
 
     if keyboard_input.just_pressed(KeyCode::KeyL) {
         // Toggle between locked and unlocked
@@ -24,6 +24,6 @@ pub fn ui_system(
     }
     
     if keyboard_input.pressed(KeyCode::Escape) {
-        app_exit_events.send(Default::default());
+        app_exit_events.write(Default::default());
     }
 }

--- a/client/src/plugins/input/systems/voxels.rs
+++ b/client/src/plugins/input/systems/voxels.rs
@@ -14,8 +14,8 @@ pub fn voxel_system(
     mut query: Query<(&mut Transform, &mut CameraController)>,
     mut windows: Query<&mut Window>,
 ) {
-    let mut window = windows.single_mut();
-    let (mut transform, _) = query.single_mut();
+    let Ok(mut window) = windows.get_single_mut() else { return };
+    let Ok((mut transform, _)) = query.get_single_mut() else { return };
 
     // =======================
     // 5) Octree Keys

--- a/client/src/plugins/ui/systems/ui_system.rs
+++ b/client/src/plugins/ui/systems/ui_system.rs
@@ -43,9 +43,9 @@ pub fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 ///  - current chunk coordinate
 
 pub fn update(
-    grids: Grids<'_, '_, i64>,         // helper from big_space
+    grids: Grids<'_, '_>,         // helper from big_space
     // we need the entity id, the cell & the local transform
-    camera_q: Query<(Entity, &GridCell<i64>, &Transform, &CameraController)>,
+    camera_q: Query<(Entity, &GridCell, &Transform, &CameraController)>,
     mut ui_q:  Query<&mut Text, With<SpeedDisplay>>,
 ) {
     let Ok((cam_ent, cell, tf, ctrl)) = camera_q.get_single() else { return };

--- a/client/src/plugins/ui/ui_plugin.rs
+++ b/client/src/plugins/ui/ui_plugin.rs
@@ -1,6 +1,5 @@
 use crate::plugins::ui::systems::ui_system::*;
 use bevy::app::{App, FixedUpdate, Plugin, PreUpdate, Startup};
-use bevy::prelude::IntoSystemConfigs;
 
 pub struct UiPlugin;
 impl Plugin for UiPlugin {


### PR DESCRIPTION
## Summary
- bump `bevy` to 0.16.1
- update hierarchy API usage to `ChildOf`
- wrap `Query::single` usages
- use `EventWriter::write` for exit events

## Testing
- `cargo check` *(fails: `alsa-sys` build missing system library)*

------
https://chatgpt.com/codex/tasks/task_e_684b586ee7a08326a332088f019d7c83