### PR TITLE
Add sphere editing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ tools.
 - **F3** &ndash; Toggle world grid
 - **Q**  &ndash; Insert a red voxel at the crosshair
 - **F4** &ndash; Save the current octree to `octree.bin`
+- **F5** &ndash; Toggle sphere editing mode
 - **Escape** &ndash; Quit the application
 
 ## Running

--- a/client/src/plugins/environment/systems/voxels/octree.rs
+++ b/client/src/plugins/environment/systems/voxels/octree.rs
@@ -167,6 +167,54 @@ impl SparseVoxelOctree {
         }
     }
 
+    /// Insert a sphere of voxels with the given radius (in voxels) and center.
+    pub fn insert_sphere(&mut self, center: Vec3, radius: i32, voxel: Voxel) {
+        let step = self.get_spacing_at_depth(self.max_depth);
+        let r2 = radius * radius;
+
+        for x in -radius..=radius {
+            let dx2 = x * x;
+            for y in -radius..=radius {
+                let dy2 = y * y;
+                for z in -radius..=radius {
+                    let dz2 = z * z;
+                    if dx2 + dy2 + dz2 <= r2 {
+                        let pos = Vec3::new(
+                            center.x + x as f32 * step,
+                            center.y + y as f32 * step,
+                            center.z + z as f32 * step,
+                        );
+                        self.insert(pos, voxel);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Remove all voxels inside a sphere with the given radius (in voxels).
+    pub fn remove_sphere(&mut self, center: Vec3, radius: i32) {
+        let step = self.get_spacing_at_depth(self.max_depth);
+        let r2 = radius * radius;
+
+        for x in -radius..=radius {
+            let dx2 = x * x;
+            for y in -radius..=radius {
+                let dy2 = y * y;
+                for z in -radius..=radius {
+                    let dz2 = z * z;
+                    if dx2 + dy2 + dz2 <= r2 {
+                        let pos = Vec3::new(
+                            center.x + x as f32 * step,
+                            center.y + y as f32 * step,
+                            center.z + z as f32 * step,
+                        );
+                        self.remove(pos);
+                    }
+                }
+            }
+        }
+    }
+
     fn remove_recursive(node: &mut OctreeNode, x: f32, y: f32, z: f32, depth: u32) -> bool {
         if depth == 0 {
             if node.voxel.is_some() {

--- a/client/src/plugins/input/input_plugin.rs
+++ b/client/src/plugins/input/input_plugin.rs
@@ -2,10 +2,12 @@
 use bevy::app::{App, Plugin, PreUpdate, Startup};
 use bevy::ecs::schedule::IntoScheduleConfigs;
 use bevy::prelude::Update;
+use crate::plugins::input::systems::voxels::VoxelEditMode;
 
 pub struct InputPlugin;
 impl Plugin for InputPlugin {
     fn build(&self, _app: &mut App) {
+        _app.init_resource::<VoxelEditMode>();
         _app.add_systems(
             Update,
             (


### PR DESCRIPTION
## Summary
- introduce `VoxelEditMode` resource for single and sphere editing modes
- press F5 to toggle sphere editing
- in sphere mode, mouse buttons add or remove spherical volumes
- document the new mode in the README

## Testing
- `cargo check` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc58d13a48326b1bb4ef96f07ba40