### PR TITLE
Optimize octree root expansion

### DIFF
--- a/client/src/plugins/environment/systems/voxels/chunk.rs
+++ b/client/src/plugins/environment/systems/voxels/chunk.rs
@@ -6,12 +6,12 @@ use crate::plugins::environment::systems::voxels::structure::{ChunkKey, SparseVo
 impl SparseVoxelOctree {
     pub fn chunk_has_any_voxel(&self, key: ChunkKey) -> bool {
         // world-space centre of the chunk
-        let step  = self.get_spacing_at_depth(self.max_depth);
-        let half  = self.size * 0.5;
+        let step = self.get_spacing_at_depth(self.max_depth);
+        let half = self.size * 0.5;
         let centre = Vec3::new(
-            (key.0 as f32 + 0.5) * CHUNK_SIZE as f32 * step - half,
-            (key.1 as f32 + 0.5) * CHUNK_SIZE as f32 * step - half,
-            (key.2 as f32 + 0.5) * CHUNK_SIZE as f32 * step - half,
+            self.center.x - half + (key.0 as f32 + 0.5) * CHUNK_SIZE as f32 * step,
+            self.center.y - half + (key.1 as f32 + 0.5) * CHUNK_SIZE as f32 * step,
+            self.center.z - half + (key.2 as f32 + 0.5) * CHUNK_SIZE as f32 * step,
         );
 
         // depth of the octree node that exactly matches one chunk

--- a/client/src/plugins/environment/systems/voxels/debug.rs
+++ b/client/src/plugins/environment/systems/voxels/debug.rs
@@ -13,7 +13,7 @@ pub fn visualize_octree_system(
 
         // Draw a translucent cuboid for the root
         gizmos.cuboid(
-            Transform::from_translation(octree_tf.translation).with_scale(Vec3::splat(octree.size)),
+            Transform::from_translation(octree.center).with_scale(Vec3::splat(octree.size)),
             Color::srgba(1.0, 1.0, 0.0, 0.15),
         );
 
@@ -22,7 +22,7 @@ pub fn visualize_octree_system(
         visualize_recursive_center(
             &mut gizmos,
             &octree.root,
-            octree_tf.translation, // center of root in world
+            octree.center, // center of root in world
             octree.size,
             0,
             octree.max_depth,
@@ -103,9 +103,9 @@ pub fn draw_grid(
     };
     let camera_pos = camera_tf.translation;
 
-    for (octree, octree_tf) in octree_query.iter() {
+    for (octree, _octree_tf) in octree_query.iter() {
         let half_size = octree.size * 0.5;
-        let root_center = octree_tf.translation;
+        let root_center = octree.center;
 
         // Voxel spacing at max depth
         let spacing = octree.get_spacing_at_depth(octree.max_depth);

--- a/client/src/plugins/environment/systems/voxels/octree.rs
+++ b/client/src/plugins/environment/systems/voxels/octree.rs
@@ -26,6 +26,7 @@ impl SparseVoxelOctree {
             root: OctreeNode::new(),
             max_depth,
             size,
+            center: Vec3::ZERO,
             show_wireframe,
             show_world_grid,
             dirty: Vec::new(),
@@ -125,9 +126,9 @@ impl SparseVoxelOctree {
         let step = self.get_spacing_at_depth(self.max_depth);
         let half = self.size * 0.5;
 
-        let gx = ((position.x + half) / step).floor() as i32;
-        let gy = ((position.y + half) / step).floor() as i32;
-        let gz = ((position.z + half) / step).floor() as i32;
+        let gx = ((position.x - self.center.x + half) / step).floor() as i32;
+        let gy = ((position.y - self.center.y + half) / step).floor() as i32;
+        let gz = ((position.z - self.center.z + half) / step).floor() as i32;
 
         let lx = gx - key.0 * CHUNK_SIZE;
         let ly = gy - key.1 * CHUNK_SIZE;
@@ -272,32 +273,65 @@ impl SparseVoxelOctree {
         false
     }
 
-    fn expand_root(&mut self, _x: f32, _y: f32, _z: f32) {
+    fn expand_root(&mut self, x: f32, y: f32, z: f32) {
         info!("Root expanding ...");
-        // Save the old root and its size.
-        let old_root = std::mem::replace(&mut self.root, OctreeNode::new());
-        let old_size = self.size;
 
-        // Update the octree's size and depth.
+        // Save the old root
+        let old_root = std::mem::replace(&mut self.root, OctreeNode::new());
+        let old_center = self.center;
+        let old_size = self.size;
+        let half = old_size * 0.5;
+
+        // Determine in which direction to expand along each axis
+        let mut shift = Vec3::ZERO;
+        if x >= old_center.x {
+            shift.x = half;
+        } else {
+            shift.x = -half;
+        }
+        if y >= old_center.y {
+            shift.y = half;
+        } else {
+            shift.y = -half;
+        }
+        if z >= old_center.z {
+            shift.z = half;
+        } else {
+            shift.z = -half;
+        }
+
+        // New center after expansion
+        self.center += shift;
         self.size *= 2.0;
         self.max_depth += 1;
 
-        // Reinsert each voxel from the old tree.
-        let voxels = Self::collect_voxels_from_node(&old_root, old_size);
-        for (world_pos, voxel, _depth) in voxels {
-            self.insert(world_pos, voxel);
+        // Determine which child the old root should occupy
+        let mut index = 0usize;
+        if shift.x < 0.0 {
+            index |= 1;
         }
+        if shift.y < 0.0 {
+            index |= 2;
+        }
+        if shift.z < 0.0 {
+            index |= 4;
+        }
+
+        let mut children = Box::new(core::array::from_fn(|_| OctreeNode::new()));
+        children[index] = old_root;
+        self.root.children = Some(children);
+        self.root.is_leaf = false;
     }
 
     /// Helper: Collect all voxels from a given octree node recursively.
     /// The coordinate system here assumes the node covers [–old_size/2, +old_size/2] in each axis.
-    fn collect_voxels_from_node(node: &OctreeNode, old_size: f32) -> Vec<(Vec3, Voxel, u32)> {
+    fn collect_voxels_from_node(node: &OctreeNode, old_size: f32, center: Vec3) -> Vec<(Vec3, Voxel, u32)> {
         let mut voxels = Vec::new();
         Self::collect_voxels_recursive(
             node,
-            -old_size / 2.0,
-            -old_size / 2.0,
-            -old_size / 2.0,
+            center.x - old_size / 2.0,
+            center.y - old_size / 2.0,
+            center.z - old_size / 2.0,
             old_size,
             0,
             &mut voxels,
@@ -440,7 +474,7 @@ impl SparseVoxelOctree {
 
         // Convert the normalized neighbor coordinate back to world space
         let half_size = self.size * 0.5;
-        let neighbor_world = neighbor * self.size - Vec3::splat(half_size);
+        let neighbor_world = neighbor * self.size - Vec3::splat(half_size) + self.center;
 
         if !self.contains(neighbor_world.x, neighbor_world.y, neighbor_world.z) {
             return false;
@@ -454,8 +488,8 @@ impl SparseVoxelOctree {
         // Start from the root node
         let half_size = self.size / 2.0;
         let root_bounds = AABB {
-            min: Vec3::new(-half_size as f32, -half_size as f32, -half_size as f32),
-            max: Vec3::new(half_size as f32, half_size as f32, half_size as f32),
+            min: self.center - Vec3::splat(half_size),
+            max: self.center + Vec3::splat(half_size),
         };
         self.raycast_recursive(&self.root, ray, &root_bounds, 0)
     }
@@ -537,7 +571,7 @@ impl SparseVoxelOctree {
         self.dirty_chunks.clear();
         self.occupied_chunks.clear();
 
-        let voxels = Self::collect_voxels_from_node(&self.root, self.size);
+        let voxels = Self::collect_voxels_from_node(&self.root, self.size, self.center);
         for (pos, _voxel, _depth) in voxels {
             let key = chunk_key_from_world(self, pos);
             self.occupied_chunks.insert(key);

--- a/client/src/plugins/environment/systems/voxels/render_chunks.rs
+++ b/client/src/plugins/environment/systems/voxels/render_chunks.rs
@@ -55,9 +55,9 @@ pub fn rebuild_dirty_chunks(
                 let half = tree_ref.size * 0.5;
                 let step = tree_ref.get_spacing_at_depth(tree_ref.max_depth);
                 let origin = Vec3::new(
-                    key.0 as f32 * CHUNK_SIZE as f32 * step - half,
-                    key.1 as f32 * CHUNK_SIZE as f32 * step - half,
-                    key.2 as f32 * CHUNK_SIZE as f32 * step - half,
+                    tree_ref.center.x - half + key.0 as f32 * CHUNK_SIZE as f32 * step,
+                    tree_ref.center.y - half + key.1 as f32 * CHUNK_SIZE as f32 * step,
+                    tree_ref.center.z - half + key.2 as f32 * CHUNK_SIZE as f32 * step,
                 );
 
                 let mult = 1 << lod;

--- a/client/src/plugins/environment/systems/voxels/structure.rs
+++ b/client/src/plugins/environment/systems/voxels/structure.rs
@@ -38,6 +38,7 @@ pub struct SparseVoxelOctree {
     pub root: OctreeNode,
     pub max_depth: u32,
     pub size: f32,
+    pub center: Vec3,
     pub show_wireframe: bool,
     pub show_world_grid: bool,
 


### PR DESCRIPTION
## Summary
- track the world-space center of the octree
- replace root expansion with node shifting instead of reinsertion
- adapt coordinate helpers and chunk logic for the new center
- update debug and meshing code to respect the octree center

## Testing
- `cargo check --workspace` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec0c4af44832689fc2a2404038f34