### PR TITLE
Fix potential octree stack overflow

### DIFF
--- a/client/src/plugins/environment/systems/voxels/octree.rs
+++ b/client/src/plugins/environment/systems/voxels/octree.rs
@@ -1,6 +1,6 @@
 use crate::plugins::environment::systems::voxels::structure::{
-    AABB, CHUNK_SIZE, ChunkKey, DirtyVoxel, NEIGHBOR_OFFSETS, OctreeNode, Ray, SparseVoxelOctree,
-    Voxel,
+    ChunkKey, DirtyVoxel, OctreeNode, Ray, SparseVoxelOctree, Voxel, AABB, CHUNK_SIZE,
+    NEIGHBOR_OFFSETS,
 };
 use bevy::asset::Assets;
 use bevy::math::{DQuat, DVec3};
@@ -57,39 +57,46 @@ impl SparseVoxelOctree {
         Self::insert_recursive(&mut self.root, aligned, voxel, self.max_depth);
     }
 
-    fn insert_recursive(node: &mut OctreeNode, position: Vec3, voxel: Voxel, depth: u32) {
-        if depth == 0 {
-            node.voxel = Some(voxel);
-            node.is_leaf = true;
-            return;
-        }
+    fn insert_recursive(
+        mut node: &mut OctreeNode,
+        mut position: Vec3,
+        voxel: Voxel,
+        mut depth: u32,
+    ) {
         let epsilon = 1e-6;
-        // Determine octant index by comparing with 0.5
-        let index = ((position.x >= 0.5 - epsilon) as usize)
-            + ((position.y >= 0.5 - epsilon) as usize * 2)
-            + ((position.z >= 0.5 - epsilon) as usize * 4);
+        while depth > 0 {
+            let index = ((position.x >= 0.5 - epsilon) as usize)
+                + ((position.y >= 0.5 - epsilon) as usize * 2)
+                + ((position.z >= 0.5 - epsilon) as usize * 4);
 
-        // If there are no children, create them.
-        if node.children.is_none() {
-            node.children = Some(Box::new(core::array::from_fn(|_| OctreeNode::new())));
-            node.is_leaf = false;
+            if node.children.is_none() {
+                node.children = Some(Box::new(core::array::from_fn(|_| OctreeNode::new())));
+                node.is_leaf = false;
+            }
+
+            if let Some(ref mut children) = node.children {
+                let adjust_coord = |coord: f32| {
+                    if coord >= 0.5 - epsilon {
+                        (coord - 0.5) * 2.0
+                    } else {
+                        coord * 2.0
+                    }
+                };
+
+                position = Vec3::new(
+                    adjust_coord(position.x),
+                    adjust_coord(position.y),
+                    adjust_coord(position.z),
+                );
+
+                node = &mut children[index];
+            }
+
+            depth -= 1;
         }
-        if let Some(ref mut children) = node.children {
-            // Adjust coordinate into the child’s [0, 1] range.
-            let adjust_coord = |coord: f32| {
-                if coord >= 0.5 - epsilon {
-                    (coord - 0.5) * 2.0
-                } else {
-                    coord * 2.0
-                }
-            };
-            let child_pos = Vec3::new(
-                adjust_coord(position.x),
-                adjust_coord(position.y),
-                adjust_coord(position.z),
-            );
-            Self::insert_recursive(&mut children[index], child_pos, voxel, depth - 1);
-        }
+
+        node.voxel = Some(voxel);
+        node.is_leaf = true;
     }
 
     pub fn remove(&mut self, position: Vec3) {
@@ -215,61 +222,71 @@ impl SparseVoxelOctree {
         }
     }
 
-    fn remove_recursive(node: &mut OctreeNode, x: f32, y: f32, z: f32, depth: u32) -> bool {
-        if depth == 0 {
-            if node.voxel.is_some() {
-                node.voxel = None;
-                node.is_leaf = false;
-                return true;
-            } else {
+    fn remove_recursive(
+        mut node: &mut OctreeNode,
+        mut x: f32,
+        mut y: f32,
+        mut z: f32,
+        mut depth: u32,
+    ) -> bool {
+        let epsilon = 1e-6;
+        let mut stack: Vec<(*mut OctreeNode, usize)> = Vec::new();
+
+        while depth > 0 {
+            if node.children.is_none() {
                 return false;
             }
+
+            let index = ((x >= 0.5 - epsilon) as usize)
+                + ((y >= 0.5 - epsilon) as usize * 2)
+                + ((z >= 0.5 - epsilon) as usize * 4);
+
+            let adjust_coord = |coord: f32| {
+                if coord >= 0.5 - epsilon {
+                    (coord - 0.5) * 2.0
+                } else {
+                    coord * 2.0
+                }
+            };
+
+            stack.push((node as *mut _, index));
+            let children = unsafe { node.children.as_mut().unwrap() };
+            node = &mut children[index];
+            x = adjust_coord(x);
+            y = adjust_coord(y);
+            z = adjust_coord(z);
+            depth -= 1;
         }
 
-        if node.children.is_none() {
+        if node.voxel.is_some() {
+            node.voxel = None;
+            node.is_leaf = false;
+        } else {
             return false;
         }
-        let epsilon = 1e-6;
-        let index = ((x >= 0.5 - epsilon) as usize)
-            + ((y >= 0.5 - epsilon) as usize * 2)
-            + ((z >= 0.5 - epsilon) as usize * 4);
 
-        let adjust_coord = |coord: f32| {
-            if coord >= 0.5 - epsilon {
-                (coord - 0.5) * 2.0
+        while let Some((parent_ptr, idx)) = stack.pop() {
+            let parent = unsafe { &mut *parent_ptr };
+            if parent.children.as_ref().unwrap()[idx].is_empty() {
+                parent.children.as_mut().unwrap()[idx] = OctreeNode::new();
             } else {
-                coord * 2.0
+                break;
             }
-        };
 
-        let child = &mut node.children.as_mut().unwrap()[index];
-        let should_prune_child = Self::remove_recursive(
-            child,
-            adjust_coord(x),
-            adjust_coord(y),
-            adjust_coord(z),
-            depth - 1,
-        );
-
-        if should_prune_child {
-            // remove the child node
-            node.children.as_mut().unwrap()[index] = OctreeNode::new();
+            if parent
+                .children
+                .as_ref()
+                .unwrap()
+                .iter()
+                .all(|c| c.is_empty())
+            {
+                parent.children = None;
+                parent.is_leaf = true;
+            } else {
+                break;
+            }
         }
-
-        // Check if all children are empty
-        let all_children_empty = node
-            .children
-            .as_ref()
-            .unwrap()
-            .iter()
-            .all(|child| child.is_empty());
-
-        if all_children_empty {
-            node.children = None;
-            node.is_leaf = true;
-            return node.voxel.is_none();
-        }
-        false
+        true
     }
 
     /// Grow the octree so that the given world-space point fits within the root.


### PR DESCRIPTION
## Summary
- refactor `insert_recursive` and `remove_recursive` to iterative loops
- reduce custom thread stack size since recursion depth is bounded

## Testing
- `cargo fmt` *(fails: rustfmt not installed)*
- `cargo test --release` *(failed: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6851cc4d624883269c05e207b2e79e94